### PR TITLE
5-Dont-fetch-column-names-for-every-row

### DIFF
--- a/src/SQLite3-Core-Tests/SQLite3RowTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3RowTest.class.st
@@ -15,7 +15,7 @@ Class {
 SQLite3RowTest >> setUp [
 	super setUp.
 	emptyRow := SQLite3Row new.
-	filledRow := SQLite3Row new.
+	filledRow := SQLite3Row new columnNames: {'foo'. 'bar'. 'pi'}; yourself.
 	filledRow
 		at: 'foo' put: 1;
 		at: 'bar' put: true;

--- a/src/SQLite3-Core/SQLite3Cursor.class.st
+++ b/src/SQLite3-Core/SQLite3Cursor.class.st
@@ -183,24 +183,12 @@ SQLite3Cursor >> rows [
 
 { #category : #API }
 SQLite3Cursor >> rowsOfClass: aRowClass [
-	| rows nc rr rv |
-
+	| rows |
 	statement ifNil: [ SQLite3Misuse signal: 'This result set does not contain a prepared statement.' ].	
 	
 	rows := OrderedCollection new.
-	[ moreRows ] whileTrue: [	
-		nc := statement dataValuesAvailable.
-		(nc = 0)
-			ifFalse: [ 
-				rr := aRowClass new.
-				0 to: nc - 1 do: [ :c | 
-					rv := statement valueOfColumn: c.
-					rr atIndex: c + 1 put: rv.
-					rr atName: (statement nameOfColumn: c) put: rv ].   
-				rr dataCount: nc. 
-				rows add: rr ].
-		moreRows := (statement step) = 100 " == SQLITE_ROW " ].
-	
+	[ moreRows ] whileTrue: [
+			rows add: (self nextOfClass: aRowClass) ].
 	^ rows
 
 ]

--- a/src/SQLite3-Core/SQLite3Cursor.class.st
+++ b/src/SQLite3-Core/SQLite3Cursor.class.st
@@ -9,7 +9,8 @@ Class {
 		'connection',
 		'statement',
 		'moreRows',
-		'rowClass'
+		'rowClass',
+		'columnNames'
 	],
 	#category : #'SQLite3-Core-Database'
 }
@@ -19,6 +20,17 @@ SQLite3Cursor >> close [
 
 	statement ifNotNil: [ statement finalize ].
 	statement := nil
+]
+
+{ #category : #accessing }
+SQLite3Cursor >> columnNames [
+	| nc |
+	^columnNames ifNil: [ 
+		nc := statement dataValuesAvailable. 
+		columnNames := Array new: nc.
+		0 to: nc - 1 do: [ :c | columnNames at: c + 1 put: (statement nameOfColumn: c) ].
+		columnNames
+	]
 ]
 
 { #category : #private }
@@ -98,7 +110,7 @@ SQLite3Cursor >> next [
 
 { #category : #API }
 SQLite3Cursor >> nextOfClass: aRowClass [
-	| nc rr rv |
+	| nc rr |
 
 	statement ifNil: [ SQLite3Misuse signal: 'This result set does not contain a prepared statement.' ].	
 	
@@ -106,19 +118,21 @@ SQLite3Cursor >> nextOfClass: aRowClass [
 		nc := statement dataValuesAvailable.
 		(nc = 0)
 			ifTrue: [ ^ nil ] 
-			ifFalse: [ 
-				rr := aRowClass new.
+			ifFalse: [
+				columnNames ifNil: [ 
+					columnNames := Array new: nc.
+					 0 to: nc - 1 do: [ :c | columnNames at: c + 1 
+							put: (statement nameOfColumn: c) ].
+					]
+				].
+				rr := aRowClass new columnNames: columnNames; yourself. 
 				0 to: nc - 1 do: [ :c | 
-					rv := statement valueOfColumn: c.
-					rr atIndex: c + 1 put: rv.
-					rr atName: (statement nameOfColumn: c) put: rv ]. 
-				rr dataCount: nc. 
-				"statement clearBindings." "XXX With this, the Glorp result set fails its test..."
-				moreRows := (statement step) = 100. " == SQLITE_ROW "
-				^ rr ]].
+					rr atIndex: c + 1 put: (statement valueOfColumn: c)].
+					"statement clearBindings." "XXX With this, the Glorp result set fails its test..."
+					moreRows := (statement step) = 100. " == SQLITE_ROW "
+					^ rr ].
 		
 	^ nil
-
 ]
 
 { #category : #API }

--- a/src/SQLite3-Core/SQLite3Row.class.st
+++ b/src/SQLite3-Core/SQLite3Row.class.st
@@ -112,7 +112,7 @@ SQLite3Row >> first [
 
 { #category : #accessing }
 SQLite3Row >> last [
-	^ self values ifEmpty: [ nil ] ifNotEmpty: [:v | v first ]
+	^ self values ifEmpty: [ nil ] ifNotEmpty: [:v | v last ]
 
 ]
 

--- a/src/SQLite3-Core/SQLite3Row.class.st
+++ b/src/SQLite3-Core/SQLite3Row.class.st
@@ -6,15 +6,25 @@ Class {
 	#name : #SQLite3Row,
 	#superclass : #Object,
 	#instVars : [
-		'data',
-		'dataCount'
+		'values',
+		'columnNames'
 	],
 	#category : #'SQLite3-Core-Database'
 }
 
-{ #category : #conversion }
+{ #category : #converting }
 SQLite3Row >> asArray [
-	^ self data asArray
+	^ self values asArray
+]
+
+{ #category : #converting }
+SQLite3Row >> asCombinedDictionary [
+	^self asDictionary addAll: ((self values collectWithIndex:[:v :i | i -> v]) asDictionary); yourself 
+]
+
+{ #category : #converting }
+SQLite3Row >> asDictionary [
+	^ Dictionary newFromKeys: self columnNames andValues: self data
 ]
 
 { #category : #accessing }
@@ -24,54 +34,64 @@ SQLite3Row >> at: aKey [
 
 { #category : #accessing }
 SQLite3Row >> at: aKey ifAbsent: aBlock [
-	^ data at: aKey ifAbsent: aBlock
+	^ aKey isInteger 
+		ifTrue: [ self values at: aKey ifAbsent: aBlock ] 
+		ifFalse: [ self values at:(self columnNames indexOf: aKey) ifAbsent: aBlock ]
 ]
 
 { #category : #accessing }
 SQLite3Row >> at: aKey put: anObject [
-	^ data at: aKey put: anObject
+	^ aKey isInteger 
+		ifTrue: [self values at: aKey put: anObject]
+		ifFalse: [ self atName: aKey put: anObject ]
 ]
 
 { #category : #accessing }
 SQLite3Row >> atIndex: anIndex [
-	^ self at: anIndex ifAbsent: [  ]
+	^ values at: anIndex ifAbsent: [  ]
 ]
 
 { #category : #accessing }
 SQLite3Row >> atIndex: anIndex put: anObject [
-	^ data at: anIndex put: anObject
+	^ self values at: anIndex put: anObject
 ]
 
 { #category : #accessing }
 SQLite3Row >> atName: aKey [ 
-	^ self at: aKey ifAbsent: [  ]
+	^ self values at: (self columnNames indexOf: aKey) ifAbsent: [ ]
 ]
 
 { #category : #accessing }
 SQLite3Row >> atName: aKey put: anObject [
-	^ data at: aKey put: anObject
+	| idx |
+	^ (idx := self columnNames indexOf: aKey) isZero 
+		ifTrue: [ 
+			columnNames := self columnNames copyWith: aKey.
+			values := self values copyWith: anObject ]
+		ifFalse: [ values at: idx put: anObject ]
 ]
 
 { #category : #accessing }
 SQLite3Row >> columnNames [
+	^ columnNames ifNil: [ #() ]
+]
+
+{ #category : #accessing }
+SQLite3Row >> columnNames: anArray [
  
-	^ self data keys
+	columnNames := anArray.
+	values := Array new: anArray size
 ]
 
 { #category : #accessing }
 SQLite3Row >> data [
-
-	 ^data
+	"compatibility"
+	 ^self asCombinedDictionary
 ]
 
 { #category : #accessing }
 SQLite3Row >> dataCount [
-	^ dataCount
-]
-
-{ #category : #accessing }
-SQLite3Row >> dataCount: anObject [
-	dataCount := anObject
+	^ self columnNames size
 ]
 
 { #category : #'reflective operations' }
@@ -86,25 +106,22 @@ SQLite3Row >> doesNotUnderstand: aMessage [
 
 { #category : #accessing }
 SQLite3Row >> first [
-	^ self atIndex: 1
+	^ self values ifEmpty: [] ifNotEmpty: [:v | v first ]
 
-]
-
-{ #category : #initialization }
-SQLite3Row >> initialize [
-	"Initializes the receiver"
-	
-	super initialize.
-	data := Dictionary new
 ]
 
 { #category : #accessing }
 SQLite3Row >> last [
-	^ self atIndex: self dataCount
+	^ self values ifEmpty: [ nil ] ifNotEmpty: [:v | v first ]
 
 ]
 
 { #category : #accessing }
 SQLite3Row >> size [
-	^ dataCount
+	^ self columnNames size
+]
+
+{ #category : #accessing }
+SQLite3Row >> values [
+	 ^values ifNil: [ #() ]
 ]


### PR DESCRIPTION
Several changes to SQLite3Row to avoid fetching the columnNames for every row (fetch em once on the cursor and share them with the rows). Also changed internal storage to array as it is a bit leaner when you have a lot of objects.  Don't fret though, values still returns a combined dictionary, asDictionary added for just the name keys, and asArray only returns the values in column order.