### PR TITLE
Add win32 module name, following convention found in other platform m…

### DIFF
--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -864,6 +864,13 @@ SQLite3Library >> win32LibraryName [
 	^ 'sqlite3'
 ]
 
+{ #category : #'private - accessing' }
+SQLite3Library >> win32ModuleName [ 
+	"Remove later - this is just to satisfy old Pharo 6"
+	
+	^self win32LibraryName
+]
+
 { #category : #operating }
 SQLite3Library >> with: aStatement at: aColumn putBlob: aByteArray [
 	^ self apiBindBlob: aStatement atColumn: aColumn with: aByteArray with: aByteArray size with: -1 


### PR DESCRIPTION
…odule code

Sqlite3 on win32 was failing, because it couldn't find library name. This fix it.