### PR TITLE
Creates a close variant that forces the release of dbHandle

### DIFF
--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -172,6 +172,13 @@ SQLite3BaseConnection >> finalize: anSQLText [
 	"no-op"	
 ]
 
+{ #category : #'public API - open/close' }
+SQLite3BaseConnection >> forceClose [
+
+	dbHandle ifNotNil: [ library close: dbHandle ].
+	self close
+]
+
 { #category : #'public API - introspection' }
 SQLite3BaseConnection >> getAutoCommit [
 

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -563,7 +563,7 @@ SQLite3Library >> clearBindings: sHandle on: dbHandle [
 
 { #category : #'connection handling' }
 SQLite3Library >> close: aHandle [	
-	^ self self apiClose: aHandle
+	^ self apiClose: aHandle
 ]
 
 { #category : #'connection handling' }


### PR DESCRIPTION
Creates a close variant that forces the release of dbHandle, (enabling you do delete the database file without closing Pharo).