### PR TITLE
Add #queryEncoding

### DIFF
--- a/src/SQLite3-Glorp/SQLite3BaseConnection.extension.st
+++ b/src/SQLite3-Glorp/SQLite3BaseConnection.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SQLite3BaseConnection }
+
+{ #category : #'*SQLite3-Glorp' }
+SQLite3BaseConnection >> queryEncoding [
+
+	^ #utf8
+]


### PR DESCRIPTION
Because it was missing and the login using `GlorpSession` fails with a DNU.

When this changes got merged pharo-rdbms/glorp#27 should work.