### PR TITLE
Fix SQL execution when not using bindings

### DIFF
--- a/src/SQLite3-Glorp/SQLite3Driver.class.st
+++ b/src/SQLite3-Glorp/SQLite3Driver.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #DatabaseDriver,
 	#instVars : [
 		'isInTransaction',
-		'transactionMutex'
+		'transactionMutex',
+		'rowCount'
 	],
 	#category : #'SQLite3-Glorp'
 }
@@ -11,7 +12,11 @@ Class {
 { #category : #executing }
 SQLite3Driver >> basicExecuteSQLString: aString [
 
-	^ self basicExecuteSQLString: aString binding: #()
+	| result |
+
+	result := self basicExecuteSQLString: aString binding: #().
+	rowCount := result rowCount.
+	^ result
 ]
 
 { #category : #executing }
@@ -64,7 +69,8 @@ SQLite3Driver >> initialize [
 
 	super initialize.
 	isInTransaction := false.
-	transactionMutex := Semaphore forMutualExclusion
+	transactionMutex := Semaphore forMutualExclusion.
+	rowCount := 0
 ]
 
 { #category : #testing }
@@ -90,4 +96,10 @@ SQLite3Driver >> rollbackTransaction [
 					isInTransaction := false
 					]
 			]
+]
+
+{ #category : #accessing }
+SQLite3Driver >> rowCount [
+
+	^ rowCount
 ]


### PR DESCRIPTION
When Glorp is not using bindings (for example on `delete:where:`) it later expects that the driver responds the `rowCount` in some cases. I'm doing here something similar to what P3 driver does.

Once this got merged, pharo-rdbms/glorp#28 can be merged. It adds a test that exposes the error fixed in this PR.

AFAIK when `basicExecuteSQLString:binding:` is used directly the driver don't need to keep the rowCount because it is asked to the result (that is some kind of Cursor), so I'm keeping track of that only when the bindings are not in use.