### PR TITLE
Deterministic finalization of prepared statement

### DIFF
--- a/src/SQLite3-Core/FFIExternalReference.extension.st
+++ b/src/SQLite3-Core/FFIExternalReference.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FFIExternalReference }
+
+{ #category : #'*SQLite3-Core' }
+FFIExternalReference >> manualRelease [
+	FFIExternalResourceManager uniqueInstance removeResource: self
+]

--- a/src/SQLite3-Core/FFIExternalResourceManager.extension.st
+++ b/src/SQLite3-Core/FFIExternalResourceManager.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FFIExternalResourceManager }
+
+{ #category : #'*SQLite3-Core' }
+FFIExternalResourceManager >> removeResource: anObject [
+	registry remove: anObject ifAbsent: [  ]
+]

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -168,8 +168,8 @@ SQLite3BaseConnection >> filename [
 ]
 
 { #category : #'public API - operating' }
-SQLite3BaseConnection >> finalize: anSQLText [ 
-	"no-op"	
+SQLite3BaseConnection >> finalize: aStatementHandle [
+	library finalize: aStatementHandle on: dbHandle
 ]
 
 { #category : #'public API - introspection' }

--- a/src/SQLite3-Core/SQLite3Connection.class.st
+++ b/src/SQLite3-Core/SQLite3Connection.class.st
@@ -44,3 +44,11 @@ SQLite3Connection >> execute: anSQLText with: aCollection [
 	^(self prepare: anSQLText) execute: aCollection
 
 ]
+
+{ #category : #'public API - operating' }
+SQLite3Connection >> execute: anSQLText with: aCollection doing: aBlock [
+	| cursor |
+	cursor := self execute: anSQLText with: aCollection.
+	[aBlock value: cursor]
+		ensure: [ cursor finalizeStatement ]
+]

--- a/src/SQLite3-Core/SQLite3Cursor.class.st
+++ b/src/SQLite3-Core/SQLite3Cursor.class.st
@@ -47,6 +47,11 @@ SQLite3Cursor >> connection [
 	^statement connection
 ]
 
+{ #category : #API }
+SQLite3Cursor >> finalizeStatement [
+	statement finalize
+]
+
 { #category : #initialization }
 SQLite3Cursor >> initialize [
 	"Initializes the receiver"

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -616,6 +616,11 @@ SQLite3Library >> execute: anSQLText on: aDBHandle [
 	
 ]
 
+{ #category : #operating }
+SQLite3Library >> finalize: aStatementHandle on: aDBHandle [
+	^ self checkForOk: (self apiFinalize: aStatementHandle) on: aDBHandle
+]
+
 { #category : #accessing }
 SQLite3Library >> floatFrom: aStatement at: aColumn [
 

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -242,12 +242,16 @@ SQLite3PreparedStatement >> execute: bindings [
 
 { #category : #initialization }
 SQLite3PreparedStatement >> finalize [
-	| result |
+	"Finalize the statement as required by the SQLite3 API. As per the API, the user is expected to finalize a statement after use.
 	
-	result := connection finalize: self sqlText.
-	"Let FFIExternalResourceManager take care."
-	"SQLite3Library current apiFinalize: handle."
-	handle := nil.
+	Since executing a new statement without having finalized the previous one might cause SQLITE_BUSY errors, we can't rely on the garbage collector to execute the finalization, or we'll be exposed to non-deterministic behaviour."
+
+	handle
+		ifNotNil:
+			[ "Remove the statement object from its finalization registry. This should happen before the actual finalization to avoid finalizing the statement twice, which might result in 'undefined and undesirable behavior such as segfaults and heap corruption' as per the SQLite3 API"
+			handle manualRelease.
+			connection finalize: handle.
+			handle := nil ].
 	^ 0
 ]
 

--- a/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
@@ -18,8 +18,3 @@ SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
 SQLite3StatementExternalObject >> finalizeResourceData: aHandle [
 	SQLite3Library current apiFinalize: aHandle.
 ]
-
-{ #category : #'external resource management' }
-SQLite3StatementExternalObject >> manualRelease [
-	self class finalizationRegistry remove: self ifAbsent: [  ]
-]

--- a/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
@@ -18,3 +18,8 @@ SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
 SQLite3StatementExternalObject >> finalizeResourceData: aHandle [
 	SQLite3Library current apiFinalize: aHandle.
 ]
+
+{ #category : #'external resource management' }
+SQLite3StatementExternalObject >> manualRelease [
+	self class finalizationRegistry remove: self ifAbsent: [  ]
+]


### PR DESCRIPTION
Reenginer the finalization logic for SQLite3PreparedStatement to allow for user-driven finalization as required by the SQLite3 API.

Do this by replacing SQLite3BaseConnection>>finalize: with a message send to the library to invoke the underlying SQLite3 API.
Keep the existing finalization mechanism (driven by the FFIExternalResourceManager) for backwards-compatibility, while avoiding finalizing twice as that's not supported by the API.

Add SQLite3Connection>>execute:with:doing: as a utility method to abstract the finalization of the statement.

Fixes #28.