### PR TITLE
Change parameter type from `ExternalAddress` to `void *`

### DIFF
--- a/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'instance finalization' }
 SQLite3DatabaseExternalObject class >> finalizeResourceData: resourceData [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_close (ExternalAddress resourceData))
+		ffiCall: #(int sqlite3_close (void *resourceData))
 ]

--- a/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #'instance finalization' }
 SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_finalize (ExternalAddress aHandle))
+		ffiCall: #(int sqlite3_finalize (void *aHandle))
 ]
 
 { #category : #finalization }


### PR DESCRIPTION
 in:

- SQLite3StatementExternalObject class>>finalizeResourceData:
- SQLite3DatabaseExternalObject class>>finalizeResourceData:

With the move to TFFI in Pharo 9 using ExternalAddress sometimes triggers an 'object is not pinned' error.

This change is backward compatible with Pharo 8 (the automated tests still pass).