### PR TITLE
Pharo 9 TFFI assumes functions with String return type are UTF8 and decodes

### DIFF
--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -868,7 +868,9 @@ SQLite3Library >> unix64ModuleName [
 SQLite3Library >> utf8StringToPharo: anUTF8String [
 	"Converts from SQLite UTF-8 to Pharo Multibyte Characters"
 	
-	^(ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd
+	^ SystemVersion current major >= 9
+		ifTrue: [ anUTF8String ]
+		ifFalse: [ (ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd ]
 ]
 
 { #category : #'private - accessing' }


### PR DESCRIPTION
Modify SQLite3Library>>utf8StringToPharo: to not decode the UTF8 in Pharo 9 and later.