### PR TITLE
Pharo 9 TFFI updates

### DIFF
--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -22,6 +22,10 @@ BaselineOfSQLite3 >> baseline: spec [
 				package: 'SQLite3-Core-Tests' with: [ spec requires: #('SQLite3-Core') ];
 				package: 'SQLite3-Glorp' with: [ spec requires: #('SQLite3-Core' 'Glorp-Core') ];
 				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
+			"Pharo version compatibility"
+			SystemVersion current major >= 9 
+				ifTrue: [ spec package: 'SQLite3-Pharo9' with: [ spec requires: #('SQLite3-Core') ] ]
+				ifFalse: [  ].
 			"Groups"
 			spec
 				group: 'Core' with: #('SQLite3-Core');

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -13,24 +13,24 @@ BaselineOfSQLite3 >> baseline: spec [
 
 	spec
 		for: #pharo
-		do: [ spec blessing: #baseline.
-			Stdio stdout
-				<< 'AKG: loading baseline';
-				lf; flush.
+		do: [ 
 			self setUpDependencies: spec.
-			"Packages"
 			spec
 				package: 'SQLite3-Core';
-				package: 'SQLite3-Core-Benchmarks' with: [ spec requires: #('SQLite3-Core') ];
-				package: 'SQLite3-Core-Tests' with: [ spec requires: #('SQLite3-Core') ];
-				package: 'SQLite3-Glorp' with: [ spec requires: #('SQLite3-Core' 'Glorp-Core') ];
-				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
-			"Groups"
-			spec
-				group: 'Core' with: #('SQLite3-Core');
-				group: 'Tests' with: #('SQLite3-Core-Tests');
-				group: 'Benchmarks' with: #('SQLite3-Core-Benchmarks');
+        group: 'Core' with: 'SQLite3-Core';
+
+				package: 'SQLite3-Core-Benchmarks' with: [ spec requires: 'SQLite3-Core' ];
+				group: 'Benchmarks' with: 'SQLite3-Core-Benchmarks';
+				
+        package: 'SQLite3-Core-Tests' with: [ spec requires: 'Core' ];
+				group: 'Tests' with: 'SQLite3-Core-Tests';
+				
+        package: 'SQLite3-Glorp' with: [ spec requires: #('Core' 'Glorp-Core') ];
 				group: 'glorp' with: 'SQLite3-Glorp';
+				
+        package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
+
+			spec
 				group: 'CI' with: #('SQLite3-Glorp-Tests' 'Tests');
 				group: 'all' with: #('Core' 'Tests' 'Benchmarks');
 				group: 'default' with: #('all')
@@ -66,9 +66,8 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 				lf; flush.
 			spec 
 				package: 'SQLite3-Pharo8';
-				group: 'Core' with: 'SQLite3-Pharo8';
-				group: 'CI' with: 'SQLite3-Pharo8';
-				group: 'glorp' with: 'SQLite3-Pharo8' ].
+				group: 'Core' with: 'SQLite3-Pharo8'
+				].
 
 	spec
 		for: #'pharo8.x'
@@ -79,9 +78,8 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 				lf; flush.
 			spec 
 				package: 'SQLite3-Pharo8';
-				group: 'Core' with: 'SQLite3-Pharo8';
-				group: 'CI' with: 'SQLite3-Pharo8';
-				group: 'glorp' with: 'SQLite3-Pharo8' ].
+				group: 'Core' with: 'SQLite3-Pharo8'
+        ].
 
 	spec
 		for: #'pharo9.x'
@@ -92,8 +90,7 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 				lf; flush.
 			spec 
 				package: 'SQLite3-Pharo9';
-				group: 'Core' with: 'SQLite3-Pharo9';
-				group: 'CI' with: 'SQLite3-Pharo9';
-				group: 'glorp' with: 'SQLite3-Pharo9' ].
+				group: 'Core' with: 'SQLite3-Pharo9'
+        ].
 
 ]

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -25,7 +25,7 @@ BaselineOfSQLite3 >> baseline: spec [
 			"Pharo version compatibility"
 			SystemVersion current major >= 9 
 				ifTrue: [ spec package: 'SQLite3-Pharo9' with: [ spec requires: #('SQLite3-Core') ] ]
-				ifFalse: [  ].
+				ifFalse: [ spec package: 'SQLite3-Pharo8' with: [ spec requires: #('SQLite3-Core') ] ].
 			"Groups"
 			spec
 				group: 'Core' with: #('SQLite3-Core');

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -9,8 +9,9 @@ Class {
 
 { #category : #baselines }
 BaselineOfSQLite3 >> baseline: spec [
-
 	<baseline>
+	| versionPackage |
+
 	spec
 		for: #pharo
 		do: [ spec blessing: #baseline.
@@ -23,12 +24,13 @@ BaselineOfSQLite3 >> baseline: spec [
 				package: 'SQLite3-Glorp' with: [ spec requires: #('SQLite3-Core' 'Glorp-Core') ];
 				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
 			"Pharo version compatibility"
-			SystemVersion current major >= 9 
-				ifTrue: [ spec package: 'SQLite3-Pharo9' with: [ spec requires: #('SQLite3-Core') ] ]
-				ifFalse: [ spec package: 'SQLite3-Pharo8' with: [ spec requires: #('SQLite3-Core') ] ].
+			versionPackage := SystemVersion current major >= 9 
+				ifTrue: [ 'SQLite3-Pharo9' ]
+				ifFalse: [ 'SQLite3-Pharo8' ].
+			spec package: versionPackage with: [ spec requires: #('SQLite3-Core') ].
 			"Groups"
 			spec
-				group: 'Core' with: #('SQLite3-Core');
+				group: 'Core' with: { 'SQLite3-Core'. versionPackage };
 				group: 'Tests' with: #('SQLite3-Core-Tests');
 				group: 'Benchmarks' with: #('SQLite3-Core-Benchmarks');
 				group: 'glorp' with: 'SQLite3-Glorp';

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -10,7 +10,6 @@ Class {
 { #category : #baselines }
 BaselineOfSQLite3 >> baseline: spec [
 	<baseline>
-	| versionPackage |
 
 	spec
 		for: #pharo
@@ -23,21 +22,17 @@ BaselineOfSQLite3 >> baseline: spec [
 				package: 'SQLite3-Core-Tests' with: [ spec requires: #('SQLite3-Core') ];
 				package: 'SQLite3-Glorp' with: [ spec requires: #('SQLite3-Core' 'Glorp-Core') ];
 				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
-			"Pharo version compatibility"
-			versionPackage := SystemVersion current major >= 9 
-				ifTrue: [ 'SQLite3-Pharo9' ]
-				ifFalse: [ 'SQLite3-Pharo8' ].
-			spec package: versionPackage with: [ spec requires: #('SQLite3-Core') ].
 			"Groups"
 			spec
-				group: 'Core' with: { 'SQLite3-Core'. versionPackage };
+				group: 'Core' with: #('SQLite3-Core');
 				group: 'Tests' with: #('SQLite3-Core-Tests');
 				group: 'Benchmarks' with: #('SQLite3-Core-Benchmarks');
 				group: 'glorp' with: 'SQLite3-Glorp';
 				group: 'CI' with: #('SQLite3-Glorp-Tests' 'Tests');
 				group: 'all' with: #('Core' 'Tests' 'Benchmarks');
 				group: 'default' with: #('all')
-			]
+			].
+	self versionSpecificBaseline: spec.
 ]
 
 { #category : #baselines }
@@ -53,4 +48,31 @@ BaselineOfSQLite3 >> setUpDependencies: spec [
 		baseline: 'Glorp' with: [ spec repository: 'github://pharo-rdbms/glorp:master/' ];
 		project: 'Glorp-Core' copyFrom: 'Glorp' with: [ spec loads: 'Core' ];
 		project: 'Glorp-Tests' copyFrom: 'Glorp' with: [ spec loads: 'Tests' ]
+]
+
+{ #category : #baselines }
+BaselineOfSQLite3 >> versionSpecificBaseline: spec [
+	"Add version specific packages to the spec"
+
+	spec
+		for: #'pharo7.x'
+		do: 
+			[ spec 
+				package: 'SQLite3-Pharo8';
+				group: 'Core' with: 'SQLite3-Pharo8' ].
+
+	spec
+		for: #'pharo8.x'
+		do: 
+			[ spec 
+				package: 'SQLite3-Pharo8';
+				group: 'Core' with: 'SQLite3-Pharo8' ].
+
+	spec
+		for: #'pharo9.x'
+		do: 
+			[ spec 
+				package: 'SQLite3-Pharo9';
+				group: 'Core' with: 'SQLite3-Pharo9' ].
+
 ]

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -14,6 +14,9 @@ BaselineOfSQLite3 >> baseline: spec [
 	spec
 		for: #pharo
 		do: [ spec blessing: #baseline.
+			Stdio stdout
+				<< 'AKG: loading baseline';
+				lf; flush.
 			self setUpDependencies: spec.
 			"Packages"
 			spec
@@ -57,7 +60,11 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 	spec
 		for: #'pharo7.x'
 		do: 
-			[ spec 
+			[ 
+			Stdio stdout
+				<< 'AKG: loading 7';
+				lf; flush.
+			spec 
 				package: 'SQLite3-Pharo8';
 				group: 'Core' with: 'SQLite3-Pharo8';
 				group: 'CI' with: 'SQLite3-Pharo8';
@@ -66,7 +73,11 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 	spec
 		for: #'pharo8.x'
 		do: 
-			[ spec 
+			[ 
+			Stdio stdout
+				<< 'AKG: loading 8';
+				lf; flush.
+			spec 
 				package: 'SQLite3-Pharo8';
 				group: 'Core' with: 'SQLite3-Pharo8';
 				group: 'CI' with: 'SQLite3-Pharo8';
@@ -75,7 +86,11 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 	spec
 		for: #'pharo9.x'
 		do: 
-			[ spec 
+			[ 
+			Stdio stdout
+				<< 'AKG: loading 9';
+				lf; flush.
+			spec 
 				package: 'SQLite3-Pharo9';
 				group: 'Core' with: 'SQLite3-Pharo9';
 				group: 'CI' with: 'SQLite3-Pharo9';

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -17,18 +17,18 @@ BaselineOfSQLite3 >> baseline: spec [
 			self setUpDependencies: spec.
 			spec
 				package: 'SQLite3-Core';
-        group: 'Core' with: 'SQLite3-Core';
+				group: 'Core' with: 'SQLite3-Core';
 
 				package: 'SQLite3-Core-Benchmarks' with: [ spec requires: 'SQLite3-Core' ];
 				group: 'Benchmarks' with: 'SQLite3-Core-Benchmarks';
 				
-        package: 'SQLite3-Core-Tests' with: [ spec requires: 'Core' ];
+				package: 'SQLite3-Core-Tests' with: [ spec requires: 'Core' ];
 				group: 'Tests' with: 'SQLite3-Core-Tests';
 				
-        package: 'SQLite3-Glorp' with: [ spec requires: #('Core' 'Glorp-Core') ];
+				package: 'SQLite3-Glorp' with: [ spec requires: #('Core' 'Glorp-Core') ];
 				group: 'glorp' with: 'SQLite3-Glorp';
 				
-        package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
+				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
 
 			spec
 				group: 'CI' with: #('SQLite3-Glorp-Tests' 'Tests');
@@ -58,39 +58,21 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 	"Add version specific packages to the spec"
 
 	spec
-		for: #'pharo7.x'
+		for: #( #'pharo7.x' #'pharo8.x' )
 		do: 
 			[ 
-			Stdio stdout
-				<< 'AKG: loading 7';
-				lf; flush.
 			spec 
 				package: 'SQLite3-Pharo8';
 				group: 'Core' with: 'SQLite3-Pharo8'
 				].
-
-	spec
-		for: #'pharo8.x'
-		do: 
-			[ 
-			Stdio stdout
-				<< 'AKG: loading 8';
-				lf; flush.
-			spec 
-				package: 'SQLite3-Pharo8';
-				group: 'Core' with: 'SQLite3-Pharo8'
-        ].
-
+	
 	spec
 		for: #'pharo9.x'
 		do: 
 			[ 
-			Stdio stdout
-				<< 'AKG: loading 9';
-				lf; flush.
 			spec 
 				package: 'SQLite3-Pharo9';
 				group: 'Core' with: 'SQLite3-Pharo9'
-        ].
+				].
 
 ]

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -59,20 +59,23 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 		do: 
 			[ spec 
 				package: 'SQLite3-Pharo8';
-				group: 'Core' with: 'SQLite3-Pharo8' ].
+				group: 'Core' with: 'SQLite3-Pharo8';
+				group: 'glorp' with: 'SQLite3-Pharo8' ].
 
 	spec
 		for: #'pharo8.x'
 		do: 
 			[ spec 
 				package: 'SQLite3-Pharo8';
-				group: 'Core' with: 'SQLite3-Pharo8' ].
+				group: 'Core' with: 'SQLite3-Pharo8';
+				group: 'glorp' with: 'SQLite3-Pharo8' ].
 
 	spec
 		for: #'pharo9.x'
 		do: 
 			[ spec 
 				package: 'SQLite3-Pharo9';
-				group: 'Core' with: 'SQLite3-Pharo9' ].
+				group: 'Core' with: 'SQLite3-Pharo9';
+				group: 'glorp' with: 'SQLite3-Pharo9' ].
 
 ]

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -60,6 +60,7 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 			[ spec 
 				package: 'SQLite3-Pharo8';
 				group: 'Core' with: 'SQLite3-Pharo8';
+				group: 'CI' with: 'SQLite3-Pharo8';
 				group: 'glorp' with: 'SQLite3-Pharo8' ].
 
 	spec
@@ -68,6 +69,7 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 			[ spec 
 				package: 'SQLite3-Pharo8';
 				group: 'Core' with: 'SQLite3-Pharo8';
+				group: 'CI' with: 'SQLite3-Pharo8';
 				group: 'glorp' with: 'SQLite3-Pharo8' ].
 
 	spec
@@ -76,6 +78,7 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 			[ spec 
 				package: 'SQLite3-Pharo9';
 				group: 'Core' with: 'SQLite3-Pharo9';
+				group: 'CI' with: 'SQLite3-Pharo9';
 				group: 'glorp' with: 'SQLite3-Pharo9' ].
 
 ]

--- a/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'instance finalization' }
 SQLite3DatabaseExternalObject class >> finalizeResourceData: resourceData [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_close (ExternalAddress resourceData))
+		ffiCall: #(int sqlite3_close (void *resourceData))
 ]

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -779,11 +779,6 @@ SQLite3Library >> step: aStatementHandle [
 
 ]
 
-{ #category : #operating }
-SQLite3Library >> stringFrom: aStatement at: aColumn [
-	^ self utf8StringToPharo: (self apiColumnText: aStatement atColumn: aColumn)
-]
-
 { #category : #stepping }
 SQLite3Library >> threadsafe [
 	"http://sqlite.org/c3ref/threadsafe.html"
@@ -862,15 +857,6 @@ SQLite3Library >> unix64ModuleName [
 	"Remove later - this is just to satisfy old Pharo 6"
 	
 	^self unix64LibraryName
-]
-
-{ #category : #'private - conversion' }
-SQLite3Library >> utf8StringToPharo: anUTF8String [
-	"Converts from SQLite UTF-8 to Pharo Multibyte Characters"
-	
-	^ SystemVersion current major >= 9
-		ifTrue: [ anUTF8String ]
-		ifFalse: [ (ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd ]
 ]
 
 { #category : #'private - accessing' }

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -868,7 +868,9 @@ SQLite3Library >> unix64ModuleName [
 SQLite3Library >> utf8StringToPharo: anUTF8String [
 	"Converts from SQLite UTF-8 to Pharo Multibyte Characters"
 	
-	^(ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd
+	^ SystemVersion current major >= 9
+		ifTrue: [ anUTF8String ]
+		ifFalse: [ (ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd ]
 ]
 
 { #category : #'private - accessing' }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -385,7 +385,11 @@ SQLite3PreparedStatement >> stepOk: aValue [
 ]
 
 { #category : #fetching }
-SQLite3PreparedStatement >> stringAt: aColumn [	 
+SQLite3PreparedStatement >> stringAt: aColumn [
+	"Answer the string from the specified column"
+
+	"#stringFrom:at: is supplied in a version specific package.
+	If there are no implementers the appropriate package needs to be loaded. :-)"
 	^ self library stringFrom: handle at: aColumn
 ]
 

--- a/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #'instance finalization' }
 SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_finalize (ExternalAddress aHandle))
+		ffiCall: #(int sqlite3_finalize (void *aHandle))
 ]
 
 { #category : #finalization }

--- a/src/SQLite3-Pharo8/SQLite3Library.extension.st
+++ b/src/SQLite3-Pharo8/SQLite3Library.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #SQLite3Library }
+
+{ #category : #'*SQLite3-Pharo8' }
+SQLite3Library >> stringFrom: aStatement at: aColumn [
+	^ self utf8StringToPharo: (self apiColumnText: aStatement atColumn: aColumn)
+]
+
+{ #category : #'*SQLite3-Pharo8' }
+SQLite3Library >> utf8StringToPharo: anUTF8String [
+	"Converts from SQLite UTF-8 to Pharo Multibyte Characters"
+	
+	^ (ZnCharacterReadStream on: anUTF8String asByteArray readStream) upToEnd
+]

--- a/src/SQLite3-Pharo8/package.st
+++ b/src/SQLite3-Pharo8/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SQLite3-Pharo8' }

--- a/src/SQLite3-Pharo9/SQLite3Library.extension.st
+++ b/src/SQLite3-Pharo9/SQLite3Library.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SQLite3Library }
+
+{ #category : #'*SQLite3-Pharo9' }
+SQLite3Library >> stringFrom: aStatement at: aColumn [
+	^ self apiColumnText: aStatement atColumn: aColumn
+]

--- a/src/SQLite3-Pharo9/package.st
+++ b/src/SQLite3-Pharo9/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SQLite3-Pharo9' }


### PR DESCRIPTION
This PR makes two changes for Pharo 9 compatibility:

- Change parameter type from `ExternalAddress` to `void *` to prevent 'object not pinned' errors.
- Pharo 9 TFFI assumes functions with String return type are UTF8 and decodes

Changes:

- Change the parameter type in:

    SQLite3StatementExternalObject class>>finalizeResourceData:
    SQLite3DatabaseExternalObject class>>finalizeResourceData:

- Modify SQLite3Library>>utf8StringToPharo: to not decode the UTF8 in Pharo 9 and later.