### PR TITLE
Fix library loading under macOS 11

### DIFF
--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -676,7 +676,7 @@ SQLite3Library >> loadExtension: dbHandle with: aFilename [
 SQLite3Library >> macLibraryName [
 	| pluginDir |
 	pluginDir := FileSystem /'usr'/'lib'.
-	#('libsqlite3.dylib' 'libsqlite3.0.dylib')
+	#('libsqlite3.dylib' 'libsqlite3.0.dylib' 'sqlite3/libtclsqlite3.dylib')
 		detect: [ :each | (pluginDir / each) exists ] 
 		ifFound: [ :libName | ^ (pluginDir / libName) fullName  ].
 


### PR DESCRIPTION
Add the new location of the SQLite3 library under macOS 11 to SQLite3Library >> macLibraryName.

Fixes #34.