### PR TITLE
Tool extensions

### DIFF
--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -28,11 +28,14 @@ BaselineOfSQLite3 >> baseline: spec [
 				package: 'SQLite3-Glorp' with: [ spec requires: #('Core' 'Glorp-Core') ];
 				group: 'glorp' with: 'SQLite3-Glorp';
 				
+				package: 'SQLite3-Inspector-Extensions' with: [ spec requires: #('Core') ];
+				group: 'Tools' with: 'SQLite3-Inspector-Extensions';
+				
 				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
 
 			spec
 				group: 'CI' with: #('SQLite3-Glorp-Tests' 'Tests');
-				group: 'all' with: #('Core' 'Tests' 'Benchmarks');
+				group: 'all' with: #('Core' 'Tests' 'Benchmarks' 'Tools');
 				group: 'default' with: #('all')
 			].
 	self versionSpecificBaseline: spec.

--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -28,9 +28,6 @@ BaselineOfSQLite3 >> baseline: spec [
 				package: 'SQLite3-Glorp' with: [ spec requires: #('Core' 'Glorp-Core') ];
 				group: 'glorp' with: 'SQLite3-Glorp';
 				
-				package: 'SQLite3-Inspector-Extensions' with: [ spec requires: #('Core') ];
-				group: 'Tools' with: 'SQLite3-Inspector-Extensions';
-				
 				package: 'SQLite3-Glorp-Tests' with: [ spec requires: #('SQLite3-Glorp' 'Glorp-Tests') ].
 
 			spec
@@ -70,8 +67,14 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 		spec
 			package: 'SQLite3-Pharo9';
 			group: 'Core' with: 'SQLite3-Pharo9' ].
+	
 	spec for: #'pharo10.x' do: [ 
 		spec
 			package: 'SQLite3-Pharo10';
-			group: 'Core' with: 'SQLite3-Pharo10' ]
+			group: 'Core' with: 'SQLite3-Pharo10'.
+			
+		spec 
+			package: 'SQLite3-Inspector-Extensions' with: [ spec requires: #('Core') ];
+			group: 'Tools' with: 'SQLite3-Inspector-Extensions'	
+	]
 ]

--- a/src/SQLite3-Core-Benchmarks/ManifestSQLite3CoreBenchmarks.class.st
+++ b/src/SQLite3-Core-Benchmarks/ManifestSQLite3CoreBenchmarks.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'SQLite3-Core-Benchmarks-Manifest'
 }
 
+{ #category : #'code coverage' }
+ManifestSQLite3CoreBenchmarks class >> classNamesNotUnderTest [
+
+	^ #( ManifestSQLite3CoreBenchmarks )
+]
+
 { #category : #'code-critics' }
 ManifestSQLite3CoreBenchmarks class >> ruleClassNotReferencedRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#SQLite3Benchmark)) #'2022-05-10T08:25:40.035+02:00') )

--- a/src/SQLite3-Core-Benchmarks/ManifestSQLite3CoreBenchmarks.class.st
+++ b/src/SQLite3-Core-Benchmarks/ManifestSQLite3CoreBenchmarks.class.st
@@ -1,0 +1,13 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestSQLite3CoreBenchmarks,
+	#superclass : #PackageManifest,
+	#category : #'SQLite3-Core-Benchmarks-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestSQLite3CoreBenchmarks class >> ruleClassNotReferencedRuleV1FalsePositive [
+	^ #(#(#(#RGClassDefinition #(#SQLite3Benchmark)) #'2022-05-10T08:25:40.035+02:00') )
+]

--- a/src/SQLite3-Core-Benchmarks/SQLite3Benchmark.class.st
+++ b/src/SQLite3-Core-Benchmarks/SQLite3Benchmark.class.st
@@ -2,7 +2,7 @@
 Benchmarking harness.
 "
 Class {
-	#name : #SQLiteBenchmark,
+	#name : #SQLite3Benchmark,
 	#superclass : #Object,
 	#instVars : [
 		'db',
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : #running }
-SQLiteBenchmark >> basicExecute: anSQLText times: aCount [
+SQLite3Benchmark >> basicExecute: anSQLText times: aCount [
 	
 	db beginTransaction.
 	1 to: aCount do: [ :i |
@@ -23,17 +23,17 @@ SQLiteBenchmark >> basicExecute: anSQLText times: aCount [
 ]
 
 { #category : #'connecting-disconnecting' }
-SQLiteBenchmark >> connectBy: aConnectionClass [
+SQLite3Benchmark >> connectBy: aConnectionClass [
 	db := aConnectionClass openOn: ':memory:'
 ]
 
 { #category : #'connecting-disconnecting' }
-SQLiteBenchmark >> disconnect [
+SQLite3Benchmark >> disconnect [
 	db close
 ]
 
 { #category : #running }
-SQLiteBenchmark >> execute: anSQLText times: aCount bindingsBlock: bindingsBlock [
+SQLite3Benchmark >> execute: anSQLText times: aCount bindingsBlock: bindingsBlock [
 	
 	db beginTransaction.
 	1 to: aCount do: [ :i |
@@ -44,14 +44,14 @@ SQLiteBenchmark >> execute: anSQLText times: aCount bindingsBlock: bindingsBlock
 ]
 
 { #category : #running }
-SQLiteBenchmark >> finalizeStatement [
+SQLite3Benchmark >> finalizeStatement [
 	stmt ifNotNil: [ stmt finalize ]
 
 
 ]
 
 { #category : #running }
-SQLiteBenchmark >> prepStep: anSQLText times: aCount bindingsBlock: bindingsBlock [
+SQLite3Benchmark >> prepStep: anSQLText times: aCount bindingsBlock: bindingsBlock [
 	
 	stmt := db prepare: anSQLText.
 	db beginTransaction.
@@ -64,7 +64,7 @@ SQLiteBenchmark >> prepStep: anSQLText times: aCount bindingsBlock: bindingsBloc
 ]
 
 { #category : #running }
-SQLiteBenchmark >> runBlock: aBlock [
+SQLite3Benchmark >> runBlock: aBlock [
 	
 	db beginTransaction.
 	aBlock value: db.

--- a/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
+++ b/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #'code-critics' }
 ManifestSQLite3CoreTests class >> ruleEmptyExceptionHandlerRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#SQLite3ConnectionTest #tearDown #false)) #'2022-05-10T08:25:11.111+02:00') )
+	^ #(#(#(#RGMethodDefinition #(#SQLite3ConnectionTest #tearDown #false)) #'2022-05-10T08:25:11.111+02:00') #(#(#RGMethodDefinition #(#SQLite3BaseConnectionTest #tearDown #false)) #'2022-05-10T08:27:13.419+02:00') )
 ]
 
 { #category : #'code-critics' }

--- a/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
+++ b/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'SQLite3-Core-Tests-Manifest'
 }
 
+{ #category : #'code coverage' }
+ManifestSQLite3CoreTests class >> classNamesNotUnderTest [
+
+	^ #( ManifestSQLite3CoreTests )
+]
+
 { #category : #'code-critics' }
 ManifestSQLite3CoreTests class >> ruleEmptyExceptionHandlerRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#SQLite3ConnectionTest #tearDown #false)) #'2022-05-10T08:25:11.111+02:00') #(#(#RGMethodDefinition #(#SQLite3BaseConnectionTest #tearDown #false)) #'2022-05-10T08:27:13.419+02:00') )

--- a/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
+++ b/src/SQLite3-Core-Tests/ManifestSQLite3CoreTests.class.st
@@ -1,0 +1,23 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestSQLite3CoreTests,
+	#superclass : #PackageManifest,
+	#category : #'SQLite3-Core-Tests-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestSQLite3CoreTests class >> ruleEmptyExceptionHandlerRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#SQLite3ConnectionTest #tearDown #false)) #'2022-05-10T08:25:11.111+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestSQLite3CoreTests class >> ruleLiteralArrayContainsCommaRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#SQLite3BaseConnectionTest #deactivatedTestTracing #false)) #'2022-05-10T08:24:31.021+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestSQLite3CoreTests class >> ruleLiteralArrayContainsSuspiciousTrueFalseOrNilRuleV1FalsePositive [
+	^ #(#(#(#RGMetaclassDefinition #(#'ManifestSQLite3CoreTests class' #ManifestSQLite3CoreTests)) #'2022-05-10T08:26:37.973+02:00') )
+]

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -59,29 +59,30 @@ SQLite3BaseConnectionTest >> invalidFileNameOnCurrentOperatingSystem [
 
 { #category : #tests }
 SQLite3BaseConnectionTest >> noTestColumnNamesBobbyGo [
+
 	"In this test, Bobby Tables strikes naive SQL string construction."
+
 	"20190302, pierce: #basicExecute: uses prepare/step/finalize internally and is no longer susceptible to injection attacks. "
+
 	| tables bobby |
-	
 	res := db basicExecute: 'create table x (xk integer, xv integer);'.
-	self assert: (res = 0).
-	res := db basicExecute: 'create table students (sk integer, sname varchar);'.
-	self assert: (res = 0).
+	self assert: res equals: 0.
+	res := db basicExecute:
+		       'create table students (sk integer, sname varchar);'.
+	self assert: res equals: 0.
 
 	tables := db tableNames.
-	self assert: (tables size = 2).
-	self assert: (tables first = 'x').	
-	self assert: (tables second = 'students').	
+	self assert: tables size equals: 2.
+	self assert: tables first equals: 'x'.
+	self assert: tables second equals: 'students'.
 
-	bobby := 'x); drop table students; --'.	
-	res := db basicExecute: 'pragma table_info(', bobby, ')'.
-	self assert: (res = 0).
+	bobby := 'x); drop table students; --'.
+	res := db basicExecute: 'pragma table_info(' , bobby , ')'.
+	self assert: res equals: 0.
 
 	tables := db tableNames.
-	self assert: (tables size = 1).
-	self assert: (tables first = 'x').	
-
-
+	self assert: tables size equals: 1.
+	self assert: tables first equals: 'x'
 ]
 
 { #category : #running }

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -98,7 +98,7 @@ SQLite3BaseConnectionTest >> setUp [
 SQLite3BaseConnectionTest >> tearDown [
 	
 	[ db close ] on: SQLite3Misuse do: [ ].
-	super tearDown.
+	super tearDown
 
 ]
 

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -2,7 +2,7 @@
 Unit tests for SQLiteBaseConnection
 "
 Class {
-	#name : #SQLiteBaseConnectionTest,
+	#name : #SQLite3BaseConnectionTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'db',
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : #'tests - DEACTIVATED' }
-SQLiteBaseConnectionTest >> deactivatedTestTracing [
+SQLite3BaseConnectionTest >> deactivatedTestTracing [
 	| sql callback expected actual  |
 	
 	(SystemVersion current major >= 7) ifTrue: [ self skip ].
@@ -51,14 +51,14 @@ SQLiteBaseConnectionTest >> deactivatedTestTracing [
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> invalidFileNameOnCurrentOperatingSystem [
+SQLite3BaseConnectionTest >> invalidFileNameOnCurrentOperatingSystem [
 	^Smalltalk os isWindows
 		ifTrue: [ '/&*no' ]
 		ifFalse: [ '/nosuchfile' ]
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> noTestColumnNamesBobbyGo [
+SQLite3BaseConnectionTest >> noTestColumnNamesBobbyGo [
 	"In this test, Bobby Tables strikes naive SQL string construction."
 	"20190302, pierce: #basicExecute: uses prepare/step/finalize internally and is no longer susceptible to injection attacks. "
 	| tables bobby |
@@ -85,7 +85,7 @@ SQLiteBaseConnectionTest >> noTestColumnNamesBobbyGo [
 ]
 
 { #category : #running }
-SQLiteBaseConnectionTest >> setUp [ 
+SQLite3BaseConnectionTest >> setUp [ 
 
 	super setUp.
 	db := SQLite3BaseConnection on: ':memory:'.
@@ -94,7 +94,7 @@ SQLiteBaseConnectionTest >> setUp [
 ]
 
 { #category : #running }
-SQLiteBaseConnectionTest >> tearDown [
+SQLite3BaseConnectionTest >> tearDown [
 	
 	[ db close ] on: SQLite3Misuse do: [ ].
 	super tearDown.
@@ -102,7 +102,7 @@ SQLiteBaseConnectionTest >> tearDown [
 ]
 
 { #category : #'tests - connections' }
-SQLiteBaseConnectionTest >> testBadOpen [
+SQLite3BaseConnectionTest >> testBadOpen [
 	| newConnection |
 	newConnection := SQLite3BaseConnection
 		on: self invalidFileNameOnCurrentOperatingSystem.
@@ -111,7 +111,7 @@ SQLiteBaseConnectionTest >> testBadOpen [
 ]
 
 { #category : #'tests - execution' }
-SQLiteBaseConnectionTest >> testBasicExecuteOk [
+SQLite3BaseConnectionTest >> testBasicExecuteOk [
 
 	res := db basicExecute: 'create table x (xk integer, xv integer);'.
 	self assert: res equals: 0.
@@ -121,7 +121,7 @@ SQLiteBaseConnectionTest >> testBasicExecuteOk [
 ]
 
 { #category : #'tests - execution' }
-SQLiteBaseConnectionTest >> testBasicExecuteSyntaxError [
+SQLite3BaseConnectionTest >> testBasicExecuteSyntaxError [
 
 	self should: [ db basicExecute: 'create table,;' ]
 		raise: SQLite3AbstractError
@@ -129,7 +129,7 @@ SQLiteBaseConnectionTest >> testBasicExecuteSyntaxError [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testBooleanColumnTypeMismatch [
+SQLite3BaseConnectionTest >> testBooleanColumnTypeMismatch [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv notboolean);'.
@@ -143,7 +143,7 @@ SQLiteBaseConnectionTest >> testBooleanColumnTypeMismatch [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testBooleanObject [
+SQLite3BaseConnectionTest >> testBooleanObject [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -167,7 +167,7 @@ SQLiteBaseConnectionTest >> testBooleanObject [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteIntegerOneThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteIntegerOneThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -190,7 +190,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteIntegerOneThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteIntegerTwoThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteIntegerTwoThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -211,7 +211,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteIntegerTwoThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteIntegerZeroThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteIntegerZeroThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -234,7 +234,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteIntegerZeroThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteNilThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteNilThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -257,7 +257,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteNilThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteSQLNullThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteSQLNullThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -279,7 +279,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteSQLNullThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteStringFalseThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteStringFalseThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -302,7 +302,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteStringFalseThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteStringTrueThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteStringTrueThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -325,7 +325,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteStringTrueThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteStringTwoThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteStringTwoThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -346,7 +346,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteStringTwoThenRead [
 ]
 
 { #category : #'tests - writing' }
-SQLiteBaseConnectionTest >> testBooleanWriteThenRead [
+SQLite3BaseConnectionTest >> testBooleanWriteThenRead [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xv boolean);'.
@@ -369,7 +369,7 @@ SQLiteBaseConnectionTest >> testBooleanWriteThenRead [
 ]
 
 { #category : #'tests - columns' }
-SQLiteBaseConnectionTest >> testColumnNames [
+SQLite3BaseConnectionTest >> testColumnNames [
 	| columns |
 	
 	res := db basicExecute: 'create table x (xk integer, xv integer);'.
@@ -383,7 +383,7 @@ SQLiteBaseConnectionTest >> testColumnNames [
 ]
 
 { #category : #'tests - columns' }
-SQLiteBaseConnectionTest >> testColumnNamesBobbyStop [
+SQLite3BaseConnectionTest >> testColumnNamesBobbyStop [
 	"In this test, Bobby Tables strikes again, but fails, because #columnNamesFor: uses parameter binding."
 	| columns tables |
 	
@@ -407,7 +407,7 @@ SQLiteBaseConnectionTest >> testColumnNamesBobbyStop [
 ]
 
 { #category : #'tests - columns' }
-SQLiteBaseConnectionTest >> testColumnNamesNoSuchTable [
+SQLite3BaseConnectionTest >> testColumnNamesNoSuchTable [
 	| columns |
 	
 	res := db basicExecute: 'create table x (xk integer, xv integer);'.
@@ -417,7 +417,7 @@ SQLiteBaseConnectionTest >> testColumnNamesNoSuchTable [
 ]
 
 { #category : #'tests - connections' }
-SQLiteBaseConnectionTest >> testConstraintViolation [
+SQLite3BaseConnectionTest >> testConstraintViolation [
 	db
 		basicExecute: 'create table x (value integer primary key);';
 		basicExecute: 'insert into x values(1);'.
@@ -425,7 +425,7 @@ SQLiteBaseConnectionTest >> testConstraintViolation [
 ]
 
 { #category : #'tests - execution' }
-SQLiteBaseConnectionTest >> testDataValuesAvailable [
+SQLite3BaseConnectionTest >> testDataValuesAvailable [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, iv integer, tv text);'.
@@ -441,7 +441,7 @@ SQLiteBaseConnectionTest >> testDataValuesAvailable [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testDateAndTime [
+SQLite3BaseConnectionTest >> testDateAndTime [
 	| data s | 
 	
 	data := DateAndTime year: 2015 month: 4 day: 1.
@@ -468,7 +468,7 @@ SQLiteBaseConnectionTest >> testDateAndTime [
 ]
 
 { #category : #'tests - columns' }
-SQLiteBaseConnectionTest >> testDeclaredColumnTypes [
+SQLite3BaseConnectionTest >> testDeclaredColumnTypes [
 	| columns |
 	
 	res := db basicExecute: 'create table x (xk integer, xv blob, xb boolean);'.
@@ -481,7 +481,7 @@ SQLiteBaseConnectionTest >> testDeclaredColumnTypes [
 ]
 
 { #category : #'tests - multilingual' }
-SQLiteBaseConnectionTest >> testDefaultMultilingualStrings [
+SQLite3BaseConnectionTest >> testDefaultMultilingualStrings [
 	| s | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, xm1 text default ''中文'', xm2 text default ''áěšřčá'');'.
@@ -503,7 +503,7 @@ SQLiteBaseConnectionTest >> testDefaultMultilingualStrings [
 ]
 
 { #category : #'tests - connections' }
-SQLiteBaseConnectionTest >> testDoubleClose [
+SQLite3BaseConnectionTest >> testDoubleClose [
 	
 	db close.
 	[ db close ] on: SQLite3Misuse do: [ ]
@@ -511,7 +511,7 @@ SQLiteBaseConnectionTest >> testDoubleClose [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testFloat [
+SQLite3BaseConnectionTest >> testFloat [
 	| s |	
 	res := db basicExecute: 'create table x (xk integer primary key, xv real);'.
 	self assert: res equals: 0.
@@ -526,7 +526,7 @@ SQLiteBaseConnectionTest >> testFloat [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testInteger [
+SQLite3BaseConnectionTest >> testInteger [
 	"The large integer comes from Glorp's testInt8."
 	| s |	
 		
@@ -546,19 +546,19 @@ SQLiteBaseConnectionTest >> testInteger [
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> testIsAbstract [ 
+SQLite3BaseConnectionTest >> testIsAbstract [ 
 
 	self assert: SQLite3BaseConnection isAbstract 
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> testIsThreadsafe [
+SQLite3BaseConnectionTest >> testIsThreadsafe [
 
 	self assert: (SQLite3BaseConnection isThreadsafe isKindOf: Boolean)
 ]
 
 { #category : #'tests - multilingual' }
-SQLiteBaseConnectionTest >> testMultilingualStrings [
+SQLite3BaseConnectionTest >> testMultilingualStrings [
 	| data s idx | 
 	
 	data := OrderedCollection with: 'English' with: '中文' with: 'にほんご', 'áěšřčá'.
@@ -585,7 +585,7 @@ SQLiteBaseConnectionTest >> testMultilingualStrings [
 ]
 
 { #category : #'tests - multilingual' }
-SQLiteBaseConnectionTest >> testMultilingualTableName [
+SQLite3BaseConnectionTest >> testMultilingualTableName [
 	| s | 
 	
 	res := db basicExecute: 'create table 表一 (xk integer primary key, xm1 text default ''中文'');'.
@@ -606,7 +606,7 @@ SQLiteBaseConnectionTest >> testMultilingualTableName [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testObjectBlob [
+SQLite3BaseConnectionTest >> testObjectBlob [
 	| data s | 
 	
 	data := OrderedCollection with: 1 with: 'two' with: 3.3.
@@ -634,7 +634,7 @@ SQLiteBaseConnectionTest >> testObjectBlob [
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> testPrepareStep [
+SQLite3BaseConnectionTest >> testPrepareStep [
 	| s i sql | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, iv integer, tv text);'.
@@ -664,7 +664,7 @@ SQLiteBaseConnectionTest >> testPrepareStep [
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> testPrepareStepSelective [
+SQLite3BaseConnectionTest >> testPrepareStepSelective [
 	| s i sql count | 
 	
 	res := db basicExecute: 'create table x (xk integer primary key, iv integer, tv text);'.
@@ -698,7 +698,7 @@ SQLiteBaseConnectionTest >> testPrepareStepSelective [
 ]
 
 { #category : #tests }
-SQLiteBaseConnectionTest >> testResultSetColumnIntrospection [
+SQLite3BaseConnectionTest >> testResultSetColumnIntrospection [
 	| s | 
 
 	res := db basicExecute: 'create table x (xk integer primary key, iv integer, tv text);'.
@@ -719,7 +719,7 @@ SQLiteBaseConnectionTest >> testResultSetColumnIntrospection [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testScaledDecimal [
+SQLite3BaseConnectionTest >> testScaledDecimal [
 	"This test is a simplified version of GlorpNumericTest>>tesNumeric."
 	| s number float |
 	
@@ -742,7 +742,7 @@ SQLiteBaseConnectionTest >> testScaledDecimal [
 ]
 
 { #category : #'tests - tables' }
-SQLiteBaseConnectionTest >> testTableNames [
+SQLite3BaseConnectionTest >> testTableNames [
 
 	| tables |	
 	res := db basicExecute: 'create table x (xk integer, xv integer);'.
@@ -753,7 +753,7 @@ SQLiteBaseConnectionTest >> testTableNames [
 ]
 
 { #category : #'tests - tables' }
-SQLiteBaseConnectionTest >> testTableNamesOfEmptyDatabase [
+SQLite3BaseConnectionTest >> testTableNamesOfEmptyDatabase [
 
 	| tables |	
 	tables := db tableNames.
@@ -763,7 +763,7 @@ SQLiteBaseConnectionTest >> testTableNamesOfEmptyDatabase [
 ]
 
 { #category : #'tests - types' }
-SQLiteBaseConnectionTest >> testTime [
+SQLite3BaseConnectionTest >> testTime [
 	"SQLite3 converts a given Time instance into a DateAndTime and stores that."
 	| data today s | 
 	

--- a/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
@@ -59,3 +59,10 @@ SQLite3ColumnTest >> testPrintString [
 	self assert: firstColumn printString equals: 'a SQLite3Column("ID")'.
 	self assert: secondColumn printString equals: 'a SQLite3Column("NAME")'	
 ]
+
+{ #category : #tests }
+SQLite3ColumnTest >> testType [
+	
+	self assert: firstColumn type equals: 'INTEGER'.
+	self assert: secondColumn type equals: 'NVARCHAR(120)' 
+]

--- a/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
@@ -2,10 +2,41 @@ Class {
 	#name : #SQLite3ColumnTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'column'
+		'db',
+		'table',
+		'firstColumn',
+		'secondColumn'
 	],
 	#category : #'SQLite3-Core-Tests-Base'
 }
+
+{ #category : #running }
+SQLite3ColumnTest >> setUp [
+	super setUp.
+	db := SQLite3Database memory.
+	db connection open.
+	db connection execute: self tableCreationScript.
+	table := db tables first.
+	firstColumn := table columns first.
+	secondColumn := table columns second
+]
+
+{ #category : #accessing }
+SQLite3ColumnTest >> tableCreationScript [
+
+	^'CREATE TABLE "SAMPLE"
+(
+    [ID] INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    [NAME] NVARCHAR(120)
+)'
+]
+
+{ #category : #running }
+SQLite3ColumnTest >> tearDown [ 
+	db connection close.
+	db := nil.
+	super tearDown 
+]
 
 { #category : #tests }
 SQLite3ColumnTest >> testInitialization [
@@ -13,4 +44,18 @@ SQLite3ColumnTest >> testInitialization [
 	| instance |
 	instance := SQLite3Column new.
 	self deny: instance hasNotNullConstraint 
+]
+
+{ #category : #tests }
+SQLite3ColumnTest >> testNotNullConstraint [
+	
+	self assert: firstColumn hasNotNullConstraint.
+	self deny: secondColumn hasNotNullConstraint 
+]
+
+{ #category : #tests }
+SQLite3ColumnTest >> testPrintString [
+	
+	self assert: firstColumn printString equals: 'a SQLite3Column("ID")'.
+	self assert: secondColumn printString equals: 'a SQLite3Column("NAME")'	
 ]

--- a/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3ColumnTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #SQLite3ColumnTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'column'
+	],
+	#category : #'SQLite3-Core-Tests-Base'
+}
+
+{ #category : #tests }
+SQLite3ColumnTest >> testInitialization [
+
+	| instance |
+	instance := SQLite3Column new.
+	self deny: instance hasNotNullConstraint 
+]

--- a/src/SQLite3-Core-Tests/SQLite3ConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3ConnectionTest.class.st
@@ -2,7 +2,7 @@
 Unit tests for SQLiteConnection
 "
 Class {
-	#name : #SQLiteConnectionTest,
+	#name : #SQLite3ConnectionTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'db',
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : #utilities }
-SQLiteConnectionTest >> populateRowsInto: tableName of: database [
+SQLite3ConnectionTest >> populateRowsInto: tableName of: database [
 	| rand rows schema insert rn rt |
 	 rand := Random new.	
 	rows := rand nextInt: 100.
@@ -37,7 +37,7 @@ SQLiteConnectionTest >> populateRowsInto: tableName of: database [
 ]
 
 { #category : #running }
-SQLiteConnectionTest >> setUp [ 
+SQLite3ConnectionTest >> setUp [ 
 
 	super setUp.
 	db := SQLite3Connection memory.
@@ -46,7 +46,7 @@ SQLiteConnectionTest >> setUp [
 ]
 
 { #category : #running }
-SQLiteConnectionTest >> tearDown [
+SQLite3ConnectionTest >> tearDown [
 	
 	[ db close ] on: SQLite3Misuse do: [ ].
 	[ target ifNotNil:[target close] ] on: SQLite3Misuse do: [ ].
@@ -54,7 +54,7 @@ SQLiteConnectionTest >> tearDown [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testBackup [
+SQLite3ConnectionTest >> testBackup [
 	| row backup |
 	
 	target := SQLite3Connection memory.
@@ -73,7 +73,7 @@ SQLiteConnectionTest >> testBackup [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testChanges [
+SQLite3ConnectionTest >> testChanges [
 	| count |
 	count := self populateRowsInto: 'stuff' of: db.
 	self assert: db changes equals: 1.
@@ -83,7 +83,7 @@ SQLiteConnectionTest >> testChanges [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExactlyOneRow [
+SQLite3ConnectionTest >> testExactlyOneRow [
 	| row |
 	
 	self populateRowsInto: 'junk' of: db.
@@ -98,7 +98,7 @@ SQLiteConnectionTest >> testExactlyOneRow [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExactlyOneRowGotNone [
+SQLite3ConnectionTest >> testExactlyOneRowGotNone [
 	| row |
 	
 	self populateRowsInto: 'junk' of: db.
@@ -109,7 +109,7 @@ SQLiteConnectionTest >> testExactlyOneRowGotNone [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteDelete [
+SQLite3ConnectionTest >> testExecuteDelete [
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -121,7 +121,7 @@ SQLiteConnectionTest >> testExecuteDelete [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteDrop [
+SQLite3ConnectionTest >> testExecuteDrop [
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -133,7 +133,7 @@ SQLiteConnectionTest >> testExecuteDrop [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteNoResult [
+SQLite3ConnectionTest >> testExecuteNoResult [
 	
 	rs := db execute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: (rs next isNil).
@@ -151,7 +151,7 @@ SQLiteConnectionTest >> testExecuteNoResult [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertArray [
+SQLite3ConnectionTest >> testExecuteValueInsertArray [
 	| rd |
 		
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -182,7 +182,7 @@ SQLiteConnectionTest >> testExecuteValueInsertArray [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertBooleanNilThenSelect [
+SQLite3ConnectionTest >> testExecuteValueInsertBooleanNilThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, bv boolean);'.
@@ -216,7 +216,7 @@ SQLiteConnectionTest >> testExecuteValueInsertBooleanNilThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertBooleanThenSelect [
+SQLite3ConnectionTest >> testExecuteValueInsertBooleanThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, bv boolean);'.
@@ -248,7 +248,7 @@ SQLiteConnectionTest >> testExecuteValueInsertBooleanThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertChanges [
+SQLite3ConnectionTest >> testExecuteValueInsertChanges [
 
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -280,7 +280,7 @@ SQLiteConnectionTest >> testExecuteValueInsertChanges [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertThenSelect [
+SQLite3ConnectionTest >> testExecuteValueInsertThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -314,7 +314,7 @@ SQLiteConnectionTest >> testExecuteValueInsertThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertThenSelect2 [
+SQLite3ConnectionTest >> testExecuteValueInsertThenSelect2 [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -361,7 +361,7 @@ SQLiteConnectionTest >> testExecuteValueInsertThenSelect2 [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteValueInsertThenSelectDateTime [
+SQLite3ConnectionTest >> testExecuteValueInsertThenSelectDateTime [
 	| row data |
 	
 	res := db basicExecute: 'create table if not exists x (xv datetime);'.
@@ -395,7 +395,7 @@ SQLiteConnectionTest >> testExecuteValueInsertThenSelectDateTime [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertArray [
+SQLite3ConnectionTest >> testExecuteWithInsertArray [
 	| rd |
 		
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -426,7 +426,7 @@ SQLiteConnectionTest >> testExecuteWithInsertArray [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertBooleanNilThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertBooleanNilThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, bv boolean);'.
@@ -460,7 +460,7 @@ SQLiteConnectionTest >> testExecuteWithInsertBooleanNilThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertBooleanSQLNullThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertBooleanSQLNullThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, bv boolean);'.
@@ -492,7 +492,7 @@ SQLiteConnectionTest >> testExecuteWithInsertBooleanSQLNullThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertBooleanThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertBooleanThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, bv boolean);'.
@@ -524,7 +524,7 @@ SQLiteConnectionTest >> testExecuteWithInsertBooleanThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertChanges [
+SQLite3ConnectionTest >> testExecuteWithInsertChanges [
 
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -557,7 +557,7 @@ SQLiteConnectionTest >> testExecuteWithInsertChanges [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertDictionary [
+SQLite3ConnectionTest >> testExecuteWithInsertDictionary [
 	| rd |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -589,7 +589,7 @@ SQLiteConnectionTest >> testExecuteWithInsertDictionary [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertMultilingualStringsThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertMultilingualStringsThenSelect [
 	| data s row idx |
 	
 	data := OrderedCollection with: 'English' with: '中文' with: 'にほんご', 'áěšřčá'.
@@ -621,7 +621,7 @@ SQLiteConnectionTest >> testExecuteWithInsertMultilingualStringsThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertNoDataThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertNoDataThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key);'.
@@ -652,7 +652,7 @@ SQLiteConnectionTest >> testExecuteWithInsertNoDataThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelect [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelect [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -686,7 +686,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelect [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelect2 [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelect2 [
 	| row |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -733,7 +733,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelect2 [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelect3 [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelect3 [
 	| s row idx |
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
@@ -771,7 +771,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelect3 [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelectChineseTableName [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelectChineseTableName [
 	| data s row idx |
 	
 	data := OrderedCollection with: 'English' with: '中文' with: 'にほんご', 'áěšřčá'.
@@ -804,7 +804,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelectChineseTableName [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelectDateTime [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelectDateTime [
 	| row data |
 	
 	res := db basicExecute: 'create table if not exists x (xv datetime);'.
@@ -838,7 +838,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelectDateTime [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithInsertThenSelectJapaneseTableName [
+SQLite3ConnectionTest >> testExecuteWithInsertThenSelectJapaneseTableName [
 	| data s row idx |
 	
 	data := OrderedCollection with: 'English' with: '中文' with: 'にほんご', 'áěšřčá'.
@@ -871,7 +871,7 @@ SQLiteConnectionTest >> testExecuteWithInsertThenSelectJapaneseTableName [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithToFail [
+SQLite3ConnectionTest >> testExecuteWithToFail [
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -890,7 +890,7 @@ SQLiteConnectionTest >> testExecuteWithToFail [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testExecuteWithToFail2 [
+SQLite3ConnectionTest >> testExecuteWithToFail2 [
 	
 	res := db basicExecute: 'create table if not exists x (xk integer primary key, iv integer, tv text);'.
 	self assert: res equals: 0.
@@ -909,7 +909,7 @@ SQLiteConnectionTest >> testExecuteWithToFail2 [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testGetAutocommit [
+SQLite3ConnectionTest >> testGetAutocommit [
 	
 	self assert: db getAutoCommit equals: true.
 	db beginTransaction.
@@ -921,7 +921,7 @@ SQLiteConnectionTest >> testGetAutocommit [
 ]
 
 { #category : #'tests - glorp compatibility' }
-SQLiteConnectionTest >> testGlorpAutoID [
+SQLite3ConnectionTest >> testGlorpAutoID [
 	| schema rows |
 	
 	schema := 'CREATE TABLE BOOK (ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, STUFF TEXT NOT NULL);'.
@@ -946,7 +946,7 @@ SQLiteConnectionTest >> testGlorpAutoID [
 ]
 
 { #category : #'tests - glorp compatibility' }
-SQLiteConnectionTest >> testGlorpCompositeKey [
+SQLite3ConnectionTest >> testGlorpCompositeKey [
 	| schema rows |
 	
 	"This is the schema generated by Glorp."
@@ -968,7 +968,7 @@ SQLiteConnectionTest >> testGlorpCompositeKey [
 ]
 
 { #category : #'tests - glorp compatibility' }
-SQLiteConnectionTest >> testGlorpDoubleInsertPrimaryKey [
+SQLite3ConnectionTest >> testGlorpDoubleInsertPrimaryKey [
 	| schema rows |
 	
 	schema := 'CREATE TABLE GR_USER (ID integer  NOT NULL ,NAME text  NULL , CONSTRAINT GR_USER_PK PRIMARY KEY  (ID), CONSTRAINT GR_USER_UNIQ UNIQUE  (ID));'.
@@ -992,7 +992,7 @@ SQLiteConnectionTest >> testGlorpDoubleInsertPrimaryKey [
 ]
 
 { #category : #'tests - glorp compatibility' }
-SQLiteConnectionTest >> testGlorpUpdate [
+SQLite3ConnectionTest >> testGlorpUpdate [
 	| schema rows |
 	
 	schema := 'CREATE TABLE BOOK (ID INTEGER PRIMARY KEY AUTOINCREMENT  NOT NULL ,TITLE text  NULL ,DESCRIPTION text  NULL ,COPIES_IN_STOCK int  NULL ,VERSION int  NULL );'.
@@ -1015,7 +1015,7 @@ SQLiteConnectionTest >> testGlorpUpdate [
 ]
 
 { #category : #'tests - glorp compatibility' }
-SQLiteConnectionTest >> testGlorpUpdateTwice [
+SQLite3ConnectionTest >> testGlorpUpdateTwice [
 	| schema rows |
 	
 	schema := 'CREATE TABLE BOOK (ID INTEGER PRIMARY KEY AUTOINCREMENT  NOT NULL ,TITLE text  NULL ,DESCRIPTION text  NULL ,COPIES_IN_STOCK int  NULL ,VERSION int  NULL );'.
@@ -1039,7 +1039,7 @@ SQLiteConnectionTest >> testGlorpUpdateTwice [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testInsertThenSelectInTransaction [
+SQLite3ConnectionTest >> testInsertThenSelectInTransaction [
 	"From GlorpDatabaseBasicTest>>testNameBinding."
 	
 	res := db basicExecute: 'create table if not exists x (id integer , tv text);'.
@@ -1063,7 +1063,7 @@ SQLiteConnectionTest >> testInsertThenSelectInTransaction [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testRows [
+SQLite3ConnectionTest >> testRows [
 	"SQLite uses 1-based column indexing for database rows."
 	| rowCount rows any |
 	
@@ -1096,7 +1096,7 @@ SQLiteConnectionTest >> testRows [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testStatementReadOnly [
+SQLite3ConnectionTest >> testStatementReadOnly [
 
 	| stmt |
 	
@@ -1108,7 +1108,7 @@ SQLiteConnectionTest >> testStatementReadOnly [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> testValueInsertThenSelectInTransaction [
+SQLite3ConnectionTest >> testValueInsertThenSelectInTransaction [
 	"From GlorpDatabaseBasicTest>>testNameBinding."
 	
 	res := db basicExecute: 'create table if not exists x (id integer , tv text);'.
@@ -1132,7 +1132,7 @@ SQLiteConnectionTest >> testValueInsertThenSelectInTransaction [
 ]
 
 { #category : #tests }
-SQLiteConnectionTest >> untestStatementInProgress [
+SQLite3ConnectionTest >> untestStatementInProgress [
 	"XXX Doesn't work yet."
 	| s1 s2 |
 		

--- a/src/SQLite3-Core-Tests/SQLite3ConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3ConnectionTest.class.st
@@ -50,7 +50,7 @@ SQLite3ConnectionTest >> tearDown [
 	
 	[ db close ] on: SQLite3Misuse do: [ ].
 	[ target ifNotNil:[target close] ] on: SQLite3Misuse do: [ ].
-	super tearDown.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/SQLite3-Core-Tests/SQLite3DatabaseTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3DatabaseTest.class.st
@@ -1,0 +1,14 @@
+"
+A test class for `SQLite3Database`
+"
+Class {
+	#name : #SQLite3DatabaseTest,
+	#superclass : #TestCase,
+	#category : #'SQLite3-Core-Tests-Base'
+}
+
+{ #category : #tests }
+SQLite3DatabaseTest >> testPrintString [
+
+	self assert: SQLite3Database memory printString equals: 'a SQLite3Database(":memory:")'
+]

--- a/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
@@ -53,6 +53,12 @@ SQLite3TableTest >> testSampleTable [
 ]
 
 { #category : #'tests - sample' }
+SQLite3TableTest >> testSampleTableColumnNames [
+
+	self assert: table columnNames size equals: 2
+]
+
+{ #category : #'tests - sample' }
 SQLite3TableTest >> testSampleTableProperties [
 	|props|
 	props := table properties.

--- a/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
@@ -46,6 +46,12 @@ SQLite3TableTest >> testName [
 	self assert: instance name equals: 'SimpleTable'
 ]
 
+{ #category : #tests }
+SQLite3TableTest >> testPrintString [
+
+	self assert: table printString equals: 'a SQLite3Table("SAMPLE")'
+]
+
 { #category : #'tests - sample' }
 SQLite3TableTest >> testSampleTable [
 
@@ -56,6 +62,12 @@ SQLite3TableTest >> testSampleTable [
 SQLite3TableTest >> testSampleTableColumnNames [
 
 	self assert: table columnNames size equals: 2
+]
+
+{ #category : #'tests - sample' }
+SQLite3TableTest >> testSampleTableColumns [
+
+	self assert: table columns size equals: 2
 ]
 
 { #category : #'tests - sample' }

--- a/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
@@ -1,0 +1,24 @@
+"
+A test class for `SQLite3Table`
+"
+Class {
+	#name : #SQLite3TableTest,
+	#superclass : #TestCase,
+	#category : #'SQLite3-Core-Tests-Base'
+}
+
+{ #category : #tests }
+SQLite3TableTest >> testName [
+
+	| properties table |
+	properties := Dictionary newFromPairs: #( #name 'SimpleTable' ).
+	table := SQLite3Table properties: properties in: nil.
+	self assert: table name equals: 'SimpleTable'
+]
+
+{ #category : #tests }
+SQLite3TableTest >> testUnitializedName [ 
+
+	self assert: SQLite3Table new name equals: ''
+		
+]

--- a/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
@@ -61,7 +61,8 @@ SQLite3TableTest >> testSampleTableProperties [
 	self assert: (props at: #type) equals: 'table'.
 	self assert: (props at: #tbl_name) equals: 'SAMPLE'.
 	self assert: (props at: #rootpage) equals: 2.
-	self assert: (props at: #name) equals: 'SAMPLE'
+	self assert: (props at: #name) equals: 'SAMPLE'.
+	self assert: (props at: #sql) equals: self tableCreationScript 
 ]
 
 { #category : #'tests - sample' }

--- a/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3TableTest.class.st
@@ -4,16 +4,70 @@ A test class for `SQLite3Table`
 Class {
 	#name : #SQLite3TableTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'db',
+		'table'
+	],
 	#category : #'SQLite3-Core-Tests-Base'
 }
+
+{ #category : #running }
+SQLite3TableTest >> setUp [
+	super setUp.
+	db := SQLite3Database memory.
+	db connection open.
+	db connection execute: self tableCreationScript.
+	table := db tables first
+]
+
+{ #category : #accessing }
+SQLite3TableTest >> tableCreationScript [
+
+	^'CREATE TABLE "SAMPLE"
+(
+    [ID] INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    [NAME] NVARCHAR(120)
+)'
+]
+
+{ #category : #running }
+SQLite3TableTest >> tearDown [ 
+	db connection close.
+	db := nil.
+	super tearDown 
+]
 
 { #category : #tests }
 SQLite3TableTest >> testName [
 
-	| properties table |
+	| properties instance |
 	properties := Dictionary newFromPairs: #( #name 'SimpleTable' ).
-	table := SQLite3Table properties: properties in: nil.
-	self assert: table name equals: 'SimpleTable'
+	instance := SQLite3Table properties: properties in: nil.
+	self assert: instance name equals: 'SimpleTable'
+]
+
+{ #category : #'tests - sample' }
+SQLite3TableTest >> testSampleTable [
+
+	self assert: table name equals: 'SAMPLE'
+]
+
+{ #category : #'tests - sample' }
+SQLite3TableTest >> testSampleTableProperties [
+	|props|
+	props := table properties.
+	self assert: props size equals: 5.
+	
+	self assert: (props at: #type) equals: 'table'.
+	self assert: (props at: #tbl_name) equals: 'SAMPLE'.
+	self assert: (props at: #rootpage) equals: 2.
+	self assert: (props at: #name) equals: 'SAMPLE'
+]
+
+{ #category : #'tests - sample' }
+SQLite3TableTest >> testSampleTableSchema [
+
+	self assert: table schema equals: self tableCreationScript
 ]
 
 { #category : #tests }

--- a/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
@@ -545,6 +545,12 @@ SQLiteBaseConnectionTest >> testInteger [
 	s finalize
 ]
 
+{ #category : #tests }
+SQLiteBaseConnectionTest >> testIsAbstract [ 
+
+	self assert: SQLite3BaseConnection isAbstract 
+]
+
 { #category : #'tests - multilingual' }
 SQLiteBaseConnectionTest >> testMultilingualStrings [
 	| data s idx | 

--- a/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
@@ -551,6 +551,12 @@ SQLiteBaseConnectionTest >> testIsAbstract [
 	self assert: SQLite3BaseConnection isAbstract 
 ]
 
+{ #category : #tests }
+SQLiteBaseConnectionTest >> testIsThreadsafe [
+
+	self assert: (SQLite3BaseConnection isThreadsafe isKindOf: Boolean)
+]
+
 { #category : #'tests - multilingual' }
 SQLiteBaseConnectionTest >> testMultilingualStrings [
 	| data s idx | 

--- a/src/SQLite3-Core-Tests/SQLiteConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLiteConnectionTest.class.st
@@ -40,7 +40,7 @@ SQLiteConnectionTest >> populateRowsInto: tableName of: database [
 SQLiteConnectionTest >> setUp [ 
 
 	super setUp.
-	db := SQLite3Connection on: ':memory:'.
+	db := SQLite3Connection memory.
 	db open.
 
 ]

--- a/src/SQLite3-Core/SQLite3Backup.class.st
+++ b/src/SQLite3-Core/SQLite3Backup.class.st
@@ -15,7 +15,7 @@ Class {
 		'isOpen',
 		'handle'
 	],
-	#category : #'SQLite3-Core-Connections'
+	#category : #'SQLite3-Core-Utilities'
 }
 
 { #category : #creating }

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -1,5 +1,7 @@
 "
 I represent a connection to an SQLite database. I provide a thin wrapper over the SQLite C API.
+
+Do not use this class directory, please check and use my subclass SQLite3Connection
 "
 Class {
 	#name : #SQLite3BaseConnection,

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -25,7 +25,8 @@ SQLite3BaseConnection class >> isAbstract [
 { #category : #'instance creation' }
 SQLite3BaseConnection class >> libraryVersion [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
-	^SQLite3Library current apiLibVersion 
+	
+	^ SQLite3Library current apiLibVersion 
 ]
 
 { #category : #examples }
@@ -57,7 +58,7 @@ SQLite3BaseConnection class >> openOn: aFilename [
 SQLite3BaseConnection class >> threadsafe [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
 	
-	^SQLite3Library current threadsafe ~= 0 
+	^ SQLite3Library current threadsafe ~= 0 
 ]
 
 { #category : #'public API - backups' }

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -48,7 +48,8 @@ SQLite3BaseConnection class >> openOn: aFilename [
 { #category : #'instance creation' }
 SQLite3BaseConnection class >> threadsafe [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
-	^SQLite3Library current threadsafe != 0 
+	
+	^SQLite3Library current threadsafe ~= 0 
 ]
 
 { #category : #'public API - backups' }

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -1,7 +1,7 @@
 "
 I represent a connection to an SQLite database. I provide a thin wrapper over the SQLite C API.
 
-Do not use this class directory, please check and use my subclass SQLite3Connection
+Do not use this class directly, please check and use my subclass SQLite3Connection
 "
 Class {
 	#name : #SQLite3BaseConnection,

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -23,7 +23,7 @@ SQLite3BaseConnection class >> libraryVersion [
 { #category : #examples }
 SQLite3BaseConnection class >> memory [
 
-	^self on: ':memory:'
+	^ self on: ':memory:'
 ]
 
 { #category : #'instance creation' }

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -16,6 +16,12 @@ Class {
 	#category : #'SQLite3-Core-Connections'
 }
 
+{ #category : #testing }
+SQLite3BaseConnection class >> isAbstract [
+
+	^ self == SQLite3BaseConnection
+]
+
 { #category : #'instance creation' }
 SQLite3BaseConnection class >> libraryVersion [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -22,11 +22,11 @@ SQLite3BaseConnection class >> isAbstract [
 	^ self == SQLite3BaseConnection
 ]
 
-{ #category : #'instance creation' }
+{ #category : #accessing }
 SQLite3BaseConnection class >> libraryVersion [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
 	
-	^ SQLite3Library current apiLibVersion 
+	^ SQLite3Library current libraryVersion
 ]
 
 { #category : #examples }

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -22,6 +22,13 @@ SQLite3BaseConnection class >> isAbstract [
 	^ self == SQLite3BaseConnection
 ]
 
+{ #category : #testing }
+SQLite3BaseConnection class >> isThreadsafe [
+	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
+	
+	^ SQLite3Library current isThreadsafe ~= 0 
+]
+
 { #category : #accessing }
 SQLite3BaseConnection class >> libraryVersion [
 	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
@@ -54,11 +61,13 @@ SQLite3BaseConnection class >> openOn: aFilename [
 
 ]
 
-{ #category : #'instance creation' }
-SQLite3BaseConnection class >> threadsafe [
-	"Native Library Version http://sqlite.org/c3ref/libversion.html sqlite3_libversion"
-	
-	^ SQLite3Library current threadsafe ~= 0 
+{ #category : #testing }
+SQLite3BaseConnection class >> threadsafe [		
+	"This method is deprecated so consider to migrate."
+	self deprecated:  'Please use #isThreadsafe instead' transformWith:  '`@receiver threadsafe' 
+						-> '`@receiver isThreadsafe'.
+						
+	^ self isThreadsafe 
 ]
 
 { #category : #'public API - backups' }

--- a/src/SQLite3-Core/SQLite3Column.class.st
+++ b/src/SQLite3-Core/SQLite3Column.class.st
@@ -1,0 +1,90 @@
+"
+I represent a column in a table
+"
+Class {
+	#name : #SQLite3Column,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'index',
+		'type',
+		'hasNotNullConstraint'
+	],
+	#category : #'SQLite3-Core-Base'
+}
+
+{ #category : #'instance creation' }
+SQLite3Column class >> readFromTableInfoResult: aSQLite3Row [ 
+ 
+	^(self new)
+		name: (aSQLite3Row at: 'name');
+		index: (aSQLite3Row at: 'cid');
+		type: (aSQLite3Row at: 'type');
+		hasNotNullConstraint: (aSQLite3Row at: 'notnull') = 1;
+		yourself
+]
+
+{ #category : #accessing }
+SQLite3Column >> hasNotNullConstraint [
+
+	^ hasNotNullConstraint
+]
+
+{ #category : #accessing }
+SQLite3Column >> hasNotNullConstraint: anObject [
+
+	hasNotNullConstraint := anObject
+]
+
+{ #category : #accessing }
+SQLite3Column >> index [
+
+	^ index
+]
+
+{ #category : #accessing }
+SQLite3Column >> index: anObject [
+
+	index := anObject
+]
+
+{ #category : #initialization }
+SQLite3Column >> initialize [ 
+
+	super initialize.
+	hasNotNullConstraint := false
+]
+
+{ #category : #accessing }
+SQLite3Column >> name [
+
+	^ name
+]
+
+{ #category : #accessing }
+SQLite3Column >> name: anObject [
+
+	name := anObject
+]
+
+{ #category : #printing }
+SQLite3Column >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		<< '("';
+		<< self name;
+		<< '")'
+]
+
+{ #category : #accessing }
+SQLite3Column >> type [
+
+	^ type
+]
+
+{ #category : #accessing }
+SQLite3Column >> type: anObject [
+
+	type := anObject
+]

--- a/src/SQLite3-Core/SQLite3Connection.class.st
+++ b/src/SQLite3-Core/SQLite3Connection.class.st
@@ -49,6 +49,6 @@ SQLite3Connection >> execute: anSQLText with: aCollection [
 SQLite3Connection >> execute: anSQLText with: aCollection doing: aBlock [
 	| cursor |
 	cursor := self execute: anSQLText with: aCollection.
-	[aBlock value: cursor]
-		ensure: [ cursor finalizeStatement ]
+	^ [aBlock value: cursor]
+			ensure: [ cursor finalizeStatement ]
 ]

--- a/src/SQLite3-Core/SQLite3Database.class.st
+++ b/src/SQLite3-Core/SQLite3Database.class.st
@@ -57,17 +57,6 @@ SQLite3Database >> initConnection: aConnection [
 	connection := aConnection 
 ]
 
-{ #category : #executing }
-SQLite3Database >> inspectionSQLite3Tables [
-	<inspectorPresentationOrder: 10 title: 'Tables'>
-	 
-	^ SpTablePresenter new
-		items: self tables;
-		addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :assoc | assoc name ]);
-		addColumn: (SpStringTableColumn title: 'Number of rows' evaluated: [ :assoc | assoc numberOfRows ]);		
-		yourself
-]
-
 { #category : #printing }
 SQLite3Database >> printOn: aStream [
 

--- a/src/SQLite3-Core/SQLite3Database.class.st
+++ b/src/SQLite3-Core/SQLite3Database.class.st
@@ -1,0 +1,105 @@
+"
+An SQLite3 database
+"
+Class {
+	#name : #SQLite3Database,
+	#superclass : #Object,
+	#instVars : [
+		'connection'
+	],
+	#category : #'SQLite3-Core-Base'
+}
+
+{ #category : #'instance creation' }
+SQLite3Database class >> forConnection: aConnection [
+
+	^ self new 
+		initConnection: aConnection;
+		yourself
+]
+
+{ #category : #'instance creation' }
+SQLite3Database class >> memory [
+
+	^ self forConnection: SQLite3Connection memory
+]
+
+{ #category : #'instance creation' }
+SQLite3Database class >> on: aFilename [
+
+	^ self forConnection: (SQLite3Connection on: aFilename)
+]
+
+{ #category : #accessing }
+SQLite3Database class >> tableInfoFor: aFileName [
+	
+	| db result |
+	db := self on: aFileName.
+	db connection open.
+	 
+ 	result := db tables collect: [:each | each name -> each numberOfRows ].
+	db connection close.
+	^result
+]
+
+{ #category : #accessing }
+SQLite3Database >> connection [
+
+	^ connection
+]
+
+{ #category : #executing }
+SQLite3Database >> execute: anSQLStatement doing: aBlock [
+
+	^ self connection execute: anSQLStatement with: #(  ) doing: aBlock
+]
+
+{ #category : #'private - initialization' }
+SQLite3Database >> initConnection: aConnection [
+
+	connection := aConnection 
+]
+
+{ #category : #executing }
+SQLite3Database >> inspectionSQLite3Tables [
+	<inspectorPresentationOrder: 10 title: 'Tables'>
+	 
+	^ SpTablePresenter new
+		items: self tables;
+		addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :assoc | assoc name ]);
+		addColumn: (SpStringTableColumn title: 'Number of rows' evaluated: [ :assoc | assoc numberOfRows ]);		
+		yourself
+]
+
+{ #category : #printing }
+SQLite3Database >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		<< '("';
+		<< self connection filename;
+		<< '")'
+]
+
+{ #category : #accessing }
+SQLite3Database >> tables [
+
+	self connection isOpen ifFalse: [ ^ SQLite3NotOpen signal ].
+
+	^connection
+		execute: '
+			SELECT *
+			FROM sqlite_master
+			WHERE
+			    type =''table'' AND 
+    			name NOT LIKE ''sqlite_%'';'
+		with: #(  )
+		doing: [ :result | 
+			result rows collect: [ :eachRow | 
+				| properties |
+				properties := (eachRow columnNames collect: [ :eachCName | 
+					               eachCName -> (eachRow atName: eachCName) ])
+					              asDictionary.
+
+				SQLite3Table properties: properties in: self ] ]
+]

--- a/src/SQLite3-Core/SQLite3Database.class.st
+++ b/src/SQLite3-Core/SQLite3Database.class.st
@@ -33,13 +33,10 @@ SQLite3Database class >> on: aFilename [
 { #category : #accessing }
 SQLite3Database class >> tableInfoFor: aFileName [
 	
-	| db result |
+	| db |
 	db := self on: aFileName.
-	db connection open.
-	 
- 	result := db tables collect: [:each | each name -> each numberOfRows ].
-	db connection close.
-	^result
+	db connection open.	 
+	^ db tables
 ]
 
 { #category : #accessing }

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -782,6 +782,7 @@ SQLite3Library >> step: aStatementHandle [
 { #category : #stepping }
 SQLite3Library >> threadsafe [
 	"http://sqlite.org/c3ref/threadsafe.html"
+	
 	^self apiThreadsafe 
 	
 

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -659,6 +659,7 @@ SQLite3Library >> library [
 { #category : #accessing }
 SQLite3Library >> libraryVersion [
 	"See http://sqlite.org/c3ref/libversion.html"
+	
 	^self apiLibVersion 
 ]
 

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -645,6 +645,14 @@ SQLite3Library >> integerFrom: aStatement at: aColumn [
 	^ self apiColumnInt: aStatement atColumn: aColumn
 ]
 
+{ #category : #testing }
+SQLite3Library >> isThreadsafe [
+	"http://sqlite.org/c3ref/threadsafe.html"
+	
+	^ self apiThreadsafe 
+	
+]
+
 { #category : #accessing }
 SQLite3Library >> lastInsertRowId: dbHandle [
 
@@ -780,13 +788,13 @@ SQLite3Library >> step: aStatementHandle [
 
 ]
 
-{ #category : #stepping }
+{ #category : #testing }
 SQLite3Library >> threadsafe [
-	"http://sqlite.org/c3ref/threadsafe.html"
-	
-	^self apiThreadsafe 
-	
-
+	"This method is deprecated so consider to migrate."
+	self deprecated:  'Please use #isThreadsafe instead' transformWith:  '`@receiver threadsafe' 
+						-> '`@receiver isThreadsafe'.
+						
+	^ self isThreadsafe 
 ]
 
 { #category : #introspection }

--- a/src/SQLite3-Core/SQLite3Row.class.st
+++ b/src/SQLite3-Core/SQLite3Row.class.st
@@ -126,21 +126,6 @@ SQLite3Row >> first [
 
 ]
 
-{ #category : #converting }
-SQLite3Row >> inspectionSQLite3Row [
-	<inspectorPresentationOrder: 10 title: 'SQlite3 - Contents'>
-	 
-	| presenter |
-	presenter := SpTablePresenter new.
-	presenter items: (Array with: self).
-	self columnNames do: [:each | 
-		presenter addColumn: (SpStringTableColumn title: each evaluated: [ :assoc | self at: each ])
-		
-	].	
-		
-	^presenter	
-]
-
 { #category : #accessing }
 SQLite3Row >> last [
 	^ self values ifEmpty: [ nil ] ifNotEmpty: [:v | v last ]

--- a/src/SQLite3-Core/SQLite3Row.class.st
+++ b/src/SQLite3-Core/SQLite3Row.class.st
@@ -9,7 +9,7 @@ Class {
 		'values',
 		'columnNames'
 	],
-	#category : #'SQLite3-Core-Database'
+	#category : #'SQLite3-Core-Base'
 }
 
 { #category : #'instance creation' }
@@ -124,6 +124,21 @@ SQLite3Row >> doesNotUnderstand: aMessage [
 SQLite3Row >> first [
 	^ self values ifEmpty: [] ifNotEmpty: [:v | v first ]
 
+]
+
+{ #category : #converting }
+SQLite3Row >> inspectionSQLite3Row [
+	<inspectorPresentationOrder: 10 title: 'SQlite3 - Contents'>
+	 
+	| presenter |
+	presenter := SpTablePresenter new.
+	presenter items: (Array with: self).
+	self columnNames do: [:each | 
+		presenter addColumn: (SpStringTableColumn title: each evaluated: [ :assoc | self at: each ])
+		
+	].	
+		
+	^presenter	
 ]
 
 { #category : #accessing }

--- a/src/SQLite3-Core/SQLite3Table.class.st
+++ b/src/SQLite3-Core/SQLite3Table.class.st
@@ -22,9 +22,16 @@ SQLite3Table class >> properties: aDictionary in: aDatabase [
 { #category : #accessing }
 SQLite3Table >> columnNames [
 
+	^ self columns collect: [:each | each name ]
+]
+
+{ #category : #accessing }
+SQLite3Table >> columns [
 	^ self database
-		execute: 'SELECT * FROM ', self name , ';'
-		doing: [:result | result next columnNames ]
+		execute: 'pragma table_info(', self name , ');'
+		doing: [:result | 
+			result rows collect: [ :each |SQLite3Column readFromTableInfoResult: each ]]
+			
 ]
 
 { #category : #accessing }

--- a/src/SQLite3-Core/SQLite3Table.class.st
+++ b/src/SQLite3-Core/SQLite3Table.class.st
@@ -74,3 +74,13 @@ SQLite3Table >> properties: anObject [
 
 	properties := anObject
 ]
+
+{ #category : #accessing }
+SQLite3Table >> rows [
+
+	^ self database
+		  execute: 'SELECT *
+			FROM ', self name, '
+			LIMIT 1000;'
+		  doing: [ :result | result rows collect: [ :each | each ] ]
+]

--- a/src/SQLite3-Core/SQLite3Table.class.st
+++ b/src/SQLite3-Core/SQLite3Table.class.st
@@ -20,6 +20,14 @@ SQLite3Table class >> properties: aDictionary in: aDatabase [
 ]
 
 { #category : #accessing }
+SQLite3Table >> columnNames [
+
+	^ self database
+		execute: 'SELECT * FROM ', self name , ';'
+		doing: [:result | result next columnNames ]
+]
+
+{ #category : #accessing }
 SQLite3Table >> database [
 
 	^ database
@@ -38,10 +46,11 @@ SQLite3Table >> name [
 ]
 
 { #category : #accessing }
-SQLite3Table >> numberOfRows [ 
+SQLite3Table >> numberOfRows [
+
 	^ self database
 		execute: 'SELECT COUNT(*) FROM ', self name , ';'
-		doing: [ :each | each next at: 1 ]
+		doing: [:result | result next at: 1 ]
 ]
 
 { #category : #printing }

--- a/src/SQLite3-Core/SQLite3Table.class.st
+++ b/src/SQLite3-Core/SQLite3Table.class.st
@@ -1,0 +1,67 @@
+"
+A table within a SQLite3 database
+"
+Class {
+	#name : #SQLite3Table,
+	#superclass : #Object,
+	#instVars : [
+		'database',
+		'properties'
+	],
+	#category : #'SQLite3-Core-Base'
+}
+
+{ #category : #'instance creation' }
+SQLite3Table class >> properties: aDictionary in: aDatabase [  
+	^ self new
+		database: aDatabase;
+		properties: aDictionary;
+		yourself
+]
+
+{ #category : #accessing }
+SQLite3Table >> database [
+
+	^ database
+]
+
+{ #category : #'private - accessing' }
+SQLite3Table >> database: anObject [
+
+	database := anObject
+]
+
+{ #category : #accessing }
+SQLite3Table >> name [
+
+	^ self properties at: #name ifAbsent: [ '' ]
+]
+
+{ #category : #accessing }
+SQLite3Table >> numberOfRows [ 
+	^ self database
+		execute: 'SELECT COUNT(*) FROM ', self name , ';'
+		doing: [ :each | each next at: 1 ]
+]
+
+{ #category : #printing }
+SQLite3Table >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		<< '("';
+		<< self name;
+		<< '")'
+]
+
+{ #category : #accessing }
+SQLite3Table >> properties [
+
+	^ properties ifNil: [ properties := Dictionary new ]
+]
+
+{ #category : #'private - accessing' }
+SQLite3Table >> properties: anObject [
+
+	properties := anObject
+]

--- a/src/SQLite3-Core/SQLite3Table.class.st
+++ b/src/SQLite3-Core/SQLite3Table.class.st
@@ -84,3 +84,9 @@ SQLite3Table >> rows [
 			LIMIT 1000;'
 		  doing: [ :result | result rows collect: [ :each | each ] ]
 ]
+
+{ #category : #accessing }
+SQLite3Table >> schema [
+
+	^ self properties at: #sql ifAbsent: ''
+]

--- a/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #AbstractFileReference }
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> inspectionSQlite3 [
+	<inspectorPresentationOrder: 40 title: 'SQlite3'>
+	
+	^ SpTablePresenter new
+		addColumn: (SpStringTableColumn title: 'Table Name' evaluated: [ :assoc | assoc key ]);
+		addColumn: (SpStringTableColumn title: 'Number of Rows' evaluated: [ :assoc | assoc value ]);	
+		yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> inspectionSQlite3Context: aContext [
+
+	
+	^ aContext active: self isSQlite3Database
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> isSQlite3Database [
+	"Return true if the reference is an SQlite3 database file"
+	
+	^ self isFile and: [ 
+		  self extension = 'db' and: [ 
+			  (self readStreamDo: [ :s | s next: 16 ])
+			  = ('SQLite format 3' , Character null asString) ] ]
+]

--- a/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
@@ -2,9 +2,10 @@ Extension { #name : #AbstractFileReference }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 AbstractFileReference >> inspectionSQLite3 [
-	<inspectorPresentationOrder: 40 title: 'SQlite3'>
-	
+	<inspectorPresentationOrder: 40 title: 'SQLite3: Tables'>
+ 
 	^ SpTablePresenter new
+		items: (SQLite3Database tableInfoFor: self fullName);
 		addColumn: (SpStringTableColumn title: 'Table Name' evaluated: [ :assoc | assoc key ]);
 		addColumn: (SpStringTableColumn title: 'Number of Rows' evaluated: [ :assoc | assoc value ]);	
 		yourself
@@ -12,7 +13,6 @@ AbstractFileReference >> inspectionSQLite3 [
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 AbstractFileReference >> inspectionSQLite3Context: aContext [
-
 	
 	^ aContext active: self isSQlite3Database
 ]

--- a/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
@@ -1,18 +1,51 @@
 Extension { #name : #AbstractFileReference }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
-AbstractFileReference >> inspectionSQLite3 [
-	<inspectorPresentationOrder: 40 title: 'SQLite3: Tables'>
- 
-	^ SpTablePresenter new
-		items: (SQLite3Database tableInfoFor: self fullName);
-		addColumn: (SpStringTableColumn title: 'Table Name' evaluated: [ :assoc | assoc key ]);
-		addColumn: (SpStringTableColumn title: 'Number of Rows' evaluated: [ :assoc | assoc value ]);	
-		yourself
+AbstractFileReference >> databaseSize [
+	|s|
+	s := self size.
+	s / 1024 > 1024 ifTrue: [ ^ ((s / 1024 / 1024) roundDownTo: 0.01) asString, ' MB' ].
+	^ ((s / 1024) roundDownTo: 0.01) asString, ' KB' 	
 ]
 
 { #category : #'*SQLite3-Inspector-Extensions' }
-AbstractFileReference >> inspectionSQLite3Context: aContext [
+AbstractFileReference >> inspectionSQLite3Info [
+	<inspectorPresentationOrder: 40 title: 'SQLite3 - Info'>
+	
+	| label1 label2 |
+	label1 := SpLabeledPresenter
+		          label: 'Database file:'
+		          input: (SpTextInputFieldPresenter new text: self fullName).
+	label2 := SpLabeledPresenter
+		          label: 'Database size:'
+		          input: (SpTextInputFieldPresenter new text: self databaseSize).	
+	^ SpPresenter new
+		  layout: (SpBoxLayout newTopToBottom
+				   add: label1;
+					add: label2;
+				   yourself);
+		  yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> inspectionSQLite3InfoContext: aContext [
+	
+	^ aContext active: self isSQlite3Database
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> inspectionSQLite3Tables [
+	<inspectorPresentationOrder: 40 title: 'SQLite3 - Tables'>
+	
+	^ SpTablePresenter new
+			items: (SQLite3Database tableInfoFor: self fullName);
+			addColumn: (SpStringTableColumn title: 'Table Name' evaluated: [ :assoc | assoc name ]);
+			addColumn: (SpStringTableColumn title: 'Number of Rows' evaluated: [ :assoc | assoc numberOfRows ]);
+			yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+AbstractFileReference >> inspectionSQLite3TablesContext: aContext [
 	
 	^ aContext active: self isSQlite3Database
 ]

--- a/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #AbstractFileReference }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
-AbstractFileReference >> inspectionSQlite3 [
+AbstractFileReference >> inspectionSQLite3 [
 	<inspectorPresentationOrder: 40 title: 'SQlite3'>
 	
 	^ SpTablePresenter new
@@ -11,7 +11,7 @@ AbstractFileReference >> inspectionSQlite3 [
 ]
 
 { #category : #'*SQLite3-Inspector-Extensions' }
-AbstractFileReference >> inspectionSQlite3Context: aContext [
+AbstractFileReference >> inspectionSQLite3Context: aContext [
 
 	
 	^ aContext active: self isSQlite3Database

--- a/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/SQLite3-Inspector-Extensions/AbstractFileReference.extension.st
@@ -10,7 +10,7 @@ AbstractFileReference >> databaseSize [
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 AbstractFileReference >> inspectionSQLite3Info [
-	<inspectorPresentationOrder: 40 title: 'SQLite3 - Info'>
+	<inspectorPresentationOrder: -2 title: 'SQLite3 - Info'>
 	
 	| label1 label2 |
 	label1 := SpLabeledPresenter
@@ -35,7 +35,7 @@ AbstractFileReference >> inspectionSQLite3InfoContext: aContext [
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 AbstractFileReference >> inspectionSQLite3Tables [
-	<inspectorPresentationOrder: 40 title: 'SQLite3 - Tables'>
+	<inspectorPresentationOrder: -1 title: 'SQLite3 - Tables'>
 	
 	^ SpTablePresenter new
 			items: (SQLite3Database tableInfoFor: self fullName);

--- a/src/SQLite3-Inspector-Extensions/SQLite3Database.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Database.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SQLite3Database }
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Database >> inspectionSQLite3Tables [
+	<inspectorPresentationOrder: 10 title: 'Sqlite3 - Tables'>
+	 
+	^ SpTablePresenter new
+		items: self tables;
+		addColumn: (SpStringTableColumn title: 'Name' evaluated: [ :assoc | assoc name ]);
+		addColumn: (SpStringTableColumn title: 'Number of rows' evaluated: [ :assoc | assoc numberOfRows ]);		
+		yourself
+]

--- a/src/SQLite3-Inspector-Extensions/SQLite3Row.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Row.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #SQLite3Row }
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Row >> inspectionSQLite3Row [
+	<inspectorPresentationOrder: 10 title: 'SQlite3 - Contents'>
+	 
+	| presenter |
+	presenter := SpTablePresenter new.
+	presenter items: (Array with: self).
+	self columnNames do: [:each | 
+		presenter addColumn: (SpStringTableColumn title: each evaluated: [ :assoc | self at: each ])
+		
+	].	
+		
+	^presenter	
+]

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -7,7 +7,8 @@ SQLite3Table >> inspectionSQLite3Columns [
 	^ SpTablePresenter new
 		items: self columns;
 		addColumn: (SpStringTableColumn title: 'Column Name' evaluated: [ :each | each name ]);	
-		addColumn: (SpStringTableColumn title: 'Column Type' evaluated: [ :each | each type ]);			
+		addColumn: (SpStringTableColumn title: 'Column Type' evaluated: [ :each | each type ]);
+		addColumn: (SpStringTableColumn title: 'Non-empty values' evaluated: [ :each | each hasNotNullConstraint ifTrue: 'NOT NULL' ifFalse: '' ]);				
 		yourself
 ]
 

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -5,8 +5,9 @@ SQLite3Table >> inspectionSQLite3Columns [
 	<inspectorPresentationOrder: 13 title: 'SQLite3 - Columns'>
 	 
 	^ SpTablePresenter new
-		items: self columnNames;
-		addColumn: (SpStringTableColumn title: 'Column Name' evaluated: [ :each | each asString ]);		 
+		items: self columns;
+		addColumn: (SpStringTableColumn title: 'Column Name' evaluated: [ :each | each name ]);	
+		addColumn: (SpStringTableColumn title: 'Column Type' evaluated: [ :each | each type ]);			
 		yourself
 ]
 

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #SQLite3Table }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 SQLite3Table >> inspectionSQLite3Columns [
-	<inspectorPresentationOrder: 11 title: 'Sqlite3 - Columns'>
+	<inspectorPresentationOrder: 11 title: 'SQLite3 - Columns'>
 	 
 	^ SpTablePresenter new
 		items: self columnNames;
@@ -12,7 +12,7 @@ SQLite3Table >> inspectionSQLite3Columns [
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 SQLite3Table >> inspectionSQLite3Schema [
-	<inspectorPresentationOrder: 10 title: 'Sqlite3 - Schema'>
+	<inspectorPresentationOrder: 10 title: 'SQLite3 - Schema'>
 	 
 	^ SpTextPresenter new
 		text: self schema;
@@ -21,7 +21,7 @@ SQLite3Table >> inspectionSQLite3Schema [
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 SQLite3Table >> inspectionSQLite3TableProperties [
-	<inspectorPresentationOrder: 40 title: 'Table Properties'>
+	<inspectorPresentationOrder: 40 title: 'SQLite3 - Table Properties'>
 	 
 	^ SpTablePresenter new
 		items: self properties associations;

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -2,12 +2,26 @@ Extension { #name : #SQLite3Table }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
 SQLite3Table >> inspectionSQLite3Columns [
-	<inspectorPresentationOrder: 11 title: 'SQLite3 - Columns'>
+	<inspectorPresentationOrder: 13 title: 'SQLite3 - Columns'>
 	 
 	^ SpTablePresenter new
 		items: self columnNames;
 		addColumn: (SpStringTableColumn title: 'Column Name' evaluated: [ :each | each asString ]);		 
 		yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Table >> inspectionSQLite3Data [
+	<inspectorPresentationOrder: 11 title: 'SQLite3 - Data'>
+	 
+	| presenter |
+	presenter := SpTablePresenter new.
+	presenter items: self rows.
+	
+	self columnNames do: [:col |
+		presenter addColumn: (SpStringTableColumn title: col evaluated: [ :each | each at: col ])		 
+	 ].
+	^presenter
 ]
 
 { #category : #'*SQLite3-Inspector-Extensions' }

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -43,9 +43,3 @@ SQLite3Table >> inspectionSQLite3TableProperties [
 		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value ]);	
 		yourself
 ]
-
-{ #category : #'*SQLite3-Inspector-Extensions' }
-SQLite3Table >> schema [
-
-	^ self properties at: #sql ifAbsent: ''
-]

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -1,6 +1,25 @@
 Extension { #name : #SQLite3Table }
 
 { #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Table >> inspectionSQLite3Columns [
+	<inspectorPresentationOrder: 11 title: 'Sqlite3 - Columns'>
+	 
+	^ SpTablePresenter new
+		items: self columnNames;
+		addColumn: (SpStringTableColumn title: 'Column Name' evaluated: [ :each | each asString ]);		 
+		yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Table >> inspectionSQLite3Schema [
+	<inspectorPresentationOrder: 10 title: 'Sqlite3 - Schema'>
+	 
+	^ SpTextPresenter new
+		text: self schema;
+		yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
 SQLite3Table >> inspectionSQLite3TableProperties [
 	<inspectorPresentationOrder: 40 title: 'Table Properties'>
 	 
@@ -9,4 +28,10 @@ SQLite3Table >> inspectionSQLite3TableProperties [
 		addColumn: (SpStringTableColumn title: 'Property' evaluated: [ :assoc | assoc key ]);
 		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value ]);	
 		yourself
+]
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Table >> schema [
+
+	^ self properties at: #sql ifAbsent: ''
 ]

--- a/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
+++ b/src/SQLite3-Inspector-Extensions/SQLite3Table.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SQLite3Table }
+
+{ #category : #'*SQLite3-Inspector-Extensions' }
+SQLite3Table >> inspectionSQLite3TableProperties [
+	<inspectorPresentationOrder: 40 title: 'Table Properties'>
+	 
+	^ SpTablePresenter new
+		items: self properties associations;
+		addColumn: (SpStringTableColumn title: 'Property' evaluated: [ :assoc | assoc key ]);
+		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value ]);	
+		yourself
+]

--- a/src/SQLite3-Inspector-Extensions/package.st
+++ b/src/SQLite3-Inspector-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SQLite3-Inspector-Extensions' }


### PR DESCRIPTION
Fix several issues and add tool extensions as a package "SQLite3-Inspector-Extensions" so one can inspect tables and data directly in Pharo Spec2 based inspector

(inspired by https://github.com/khinsen/GT-SQLiteBrowser)

![image](https://user-images.githubusercontent.com/5980033/167423998-887e5dee-b63e-43b1-94d7-fc9c6ed5b568.png)
