### PR TITLE
Use sqlite3_close_v2() to close connections to the library

### DIFF
--- a/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'instance finalization' }
 SQLite3DatabaseExternalObject class >> finalizeResourceData: resourceData [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_close (void *resourceData))
+		ffiCall: #(int sqlite3_close_v2 (void *resourceData))
 ]

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -213,9 +213,9 @@ SQLite3Library >> apiClearBindings: aStatement [
 
 { #category : #'private - api' }
 SQLite3Library >> apiClose: handle [
-	"int sqlite3_close(sqlite3*)"
+	"int sqlite3_close_v2(sqlite3*)"
 	 
-	^self ffiCall: #(int sqlite3_close(sqlite3 *handle)) 
+	^self ffiCall: #(int sqlite3_close_v2(sqlite3 *handle)) 
 	 
 ]
 


### PR DESCRIPTION
Use sqlite3_close_v2() to close connections to the SQLite3 library.

The documentation in https://www.sqlite.org/c3ref/close.html states that sqlite3_close_v2() "is intended for use with host languages that are garbage collected".