### PR TITLE
Reengineer text and blob bindings to avoid segfaults in Pharo 10

### DIFF
--- a/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #'instance finalization' }
 SQLite3DatabaseExternalObject class >> finalizeResourceData: resourceData [
 	SQLite3Library current 
-		ffiCall: #(int sqlite3_close (void *resourceData))
+		ffiCall: #(int sqlite3_close_v2 (void *resourceData))
 ]

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -883,7 +883,13 @@ SQLite3Library >> win32ModuleName [
 
 { #category : #operating }
 SQLite3Library >> with: aStatement at: aColumn putBlob: aByteArray [
-	^ self apiBindBlob: aStatement atColumn: aColumn with: aByteArray with: aByteArray size with: -1 
+
+	^ self
+		  apiBindBlob: aStatement
+		  atColumn: aColumn
+		  with: aByteArray
+		  with: aByteArray size
+		  with: 0
 ]
 
 { #category : #operating }

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -213,9 +213,9 @@ SQLite3Library >> apiClearBindings: aStatement [
 
 { #category : #'private - api' }
 SQLite3Library >> apiClose: handle [
-	"int sqlite3_close(sqlite3*)"
+	"int sqlite3_close_v2(sqlite3*)"
 	 
-	^self ffiCall: #(int sqlite3_close(sqlite3 *handle)) 
+	^self ffiCall: #(int sqlite3_close_v2(sqlite3 *handle)) 
 	 
 ]
 

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -186,7 +186,7 @@ SQLite3Library >> apiBindParameterIndex: aStatement for: aName [
 ]
 
 { #category : #'private - api' }
-SQLite3Library >> apiBindString: aStatement atColumn: aColumn with: aString with: anInteger with: anotherInteger [
+SQLite3Library >> apiBindText: aStatement atColumn: aColumn with: aString with: anInteger with: anotherInteger [
 	"int sqlite3_bind_text(sqlite3_stmt*, int, const char*, int, void(*)(void*))"
 	 
 	^ self ffiCall: #(int sqlite3_bind_text (sqlite3_stmt* aStatement, int aColumn, String aString, int anInteger, int anotherInteger))
@@ -897,11 +897,9 @@ SQLite3Library >> with: aStatement at: aColumn putInteger: anInteger [
 ]
 
 { #category : #operating }
-SQLite3Library >> with: aStatement at: aColumn putString: aString [
-	| s |
-	
-	s := self pharoStringToUTF8: aString.
-	^self apiBindString: aStatement atColumn: aColumn with: s with: s size with: -1 
+SQLite3Library >> with: aStatement at: aColumn putText: aByteArray [
+
+	^self apiBindText: aStatement atColumn: aColumn with: aByteArray with: aByteArray size with: 0 
 ]
 
 { #category : #operating }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -30,7 +30,10 @@ SQLite3PreparedStatement >> at: aColumn putBoolean: aBoolean [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putByteArray: anObject [
-	^ self library with: handle at: aColumn putBlob: anObject
+
+	| byteArray |
+	byteArray := self bindingAt: anObject ifAbsentPut: [ anObject ].
+	^ self library with: handle at: aColumn putBlob: byteArray
 ]
 
 { #category : #bindings }
@@ -81,7 +84,13 @@ SQLite3PreparedStatement >> at: aColumn putNil: anObject [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putObject: anObject [
-	^ self library with: handle at: aColumn putBlob: (FLSerializer serializeToByteArray: anObject)
+
+	| blob |
+	blob := self bindingAt: anObject ifAbsentPut: [ FLSerializer serializeToByteArray: anObject ].
+	^ self library
+		  with: handle
+		  at: aColumn
+		  putBlob: blob
 ]
 
 { #category : #bindings }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -289,15 +289,15 @@ SQLite3PreparedStatement >> dbHandle [
 ]
 
 { #category : #operating }
-SQLite3PreparedStatement >> execute: bindings [ 
+SQLite3PreparedStatement >> execute: parameters [
 
 	| result |
 	self checkOk: self reset.
 	self clearBindings.
-	self bindParameters: bindings. 
+	self bindParameters: parameters.
 	result := self step.
 	changes := connection changes.
-	^SQLite3Cursor on: self
+	^ SQLite3Cursor on: self
 ]
 
 { #category : #initialization }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -136,7 +136,8 @@ SQLite3PreparedStatement >> bindParameterIndex: aName [
 ]
 
 { #category : #bindings }
-SQLite3PreparedStatement >> bindParameters: bindings [
+SQLite3PreparedStatement >> bindParameters: parameters [
+
 	"A 'variable' or 'parameter' token specifies a placeholder in the expression for a value that is filled in at runtime using the sqlite3_bind() family of C/C++ interfaces. Parameters can take several forms:
 
 ?NNN		A question mark followed by a number NNN holds a spot for the NNN-th parameter. NNN must be between 1 and SQLITE_MAX_VARIABLE_NUMBER.
@@ -146,26 +147,22 @@ SQLite3PreparedStatement >> bindParameters: bindings [
 $AAAA		A dollar-sign followed by an identifier name also holds a spot for a named parameter with the name $AAAA. The identifier name in this case can include one or more occurrences of '::' and a suffix enclosed in '(...)' containing any text at all. This syntax is the form of a variable name in the Tcl programming language. The presence of this syntax results from the fact that SQLite is really a Tcl extension that has escaped into the wild.
 Parameters that are not assigned values using sqlite3_bind() are treated as NULL. The sqlite3_bind_parameter_index() interface can be used to translate a symbolic parameter name into its equivalent numeric index."
 
-	(bindings isCollection and: [ bindings isString not ])
-		ifFalse: [ SQLite3AbstractError
-				signal: 'Unable to execute SQL on instance of ' , bindings class asString ].
-			
-	bindings
-		keysAndValuesDo: [ :k :v | 
-			| idx |
-			k isInteger
-				ifTrue: [ idx := k ]
-				ifFalse: [ idx := self bindParameterIndex: k.
-					idx = 0
-						ifTrue: [ idx := self bindParameterIndex: '@' , k ].
-					idx = 0
-						ifTrue: [ idx := self bindParameterIndex: ':' , k ].
-					idx = 0
-						ifTrue: [ idx := self bindParameterIndex: '$' , k ].
-					(idx = 0 and: [ k isAllDigits ])
-						ifTrue: [ idx := k asInteger ] ].
-			idx > 0
-				ifTrue: [ self perform: (self dataTypeForObject: v) with: idx with: v ] ]
+	(parameters isCollection and: [ parameters isString not ]) ifFalse: [ 
+		SQLite3AbstractError signal:
+			'Unable to execute SQL on instance of ' , parameters class asString ].
+
+	parameters keysAndValuesDo: [ :k :v | 
+		| idx |
+		k isInteger
+			ifTrue: [ idx := k ]
+			ifFalse: [ 
+				idx := self bindParameterIndex: k.
+				idx = 0 ifTrue: [ idx := self bindParameterIndex: '@' , k ].
+				idx = 0 ifTrue: [ idx := self bindParameterIndex: ':' , k ].
+				idx = 0 ifTrue: [ idx := self bindParameterIndex: '$' , k ].
+				(idx = 0 and: [ k isAllDigits ]) ifTrue: [ idx := k asInteger ] ].
+		idx > 0 ifTrue: [ 
+			self perform: (self dataTypeForObject: v) with: idx with: v ] ]
 ]
 
 { #category : #bindings }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -8,7 +8,8 @@ Class {
 		'connection',
 		'handle',
 		'changes',
-		'columnNames'
+		'columnNames',
+		'bindings'
 	],
 	#pools : [
 		'SQLite3Constants'
@@ -36,18 +37,23 @@ SQLite3PreparedStatement >> at: aColumn putByteArray: anObject [
 SQLite3PreparedStatement >> at: aColumn putDate: aDate [
 
 	| string |
-
-	string := SQLite3DateTimeString
-		streamContents: [ :stream | BasicDatePrinter new printDate: aDate format: #() on: stream ].
-	^ self library with: handle at: aColumn putString: string
+	string := self bindingAt: aDate ifAbsentPut: [ 
+		          SQLite3DateTimeString streamContents: [ :stream | 
+			          BasicDatePrinter new
+				          printDate: aDate
+				          format: #(  )
+				          on: stream ] ].
+	^ self library with: handle at: aColumn putText: string
 ]
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putDateTime: aDateTime [
+
 	| s |
-	
-	s := SQLite3DateTimeString streamContents: [ :stream | aDateTime asDateAndTime printOn: stream ].
-	^ self library with: handle at: aColumn putString: s
+	s := self bindingAt: aDateTime ifAbsentPut: [ 
+		     SQLite3DateTimeString streamContents: [ :stream | 
+			     aDateTime asDateAndTime printOn: stream ] ].
+	^ self library with: handle at: aColumn putText: s
 ]
 
 { #category : #bindings }
@@ -80,16 +86,21 @@ SQLite3PreparedStatement >> at: aColumn putObject: anObject [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putString: aString [
-	^ self library with: handle at: aColumn putString: aString
+
+	| s |
+	s := self bindingAt: aString
+		     ifAbsentPut: [ self library pharoStringToUTF8: aString ].
+	^ self library with: handle at: aColumn putText: s
 ]
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putTime: aTime [
 
 	| string |
-
-	string := SQLite3DateTimeString streamContents: [ :stream | aTime printOn: stream ].
-	^ self library with: handle at: aColumn putString: string
+	string := self bindingAt: aTime ifAbsentPut: [ 
+		          SQLite3DateTimeString streamContents: [ :stream | 
+			          aTime printOn: stream ] ].
+	^ self library with: handle at: aColumn putText: string
 ]
 
 { #category : #public }
@@ -148,6 +159,11 @@ Parameters that are not assigned values using sqlite3_bind() are treated as NULL
 				ifTrue: [ self perform: (self dataTypeForObject: v) with: idx with: v ] ]
 ]
 
+{ #category : #bindings }
+SQLite3PreparedStatement >> bindingAt: anObject ifAbsentPut: aBlock [
+	^bindings at: anObject ifAbsentPut: aBlock
+]
+
 { #category : #fetching }
 SQLite3PreparedStatement >> booleanAt: aColumn [ 
 	^self library booleanFrom: handle at: aColumn
@@ -182,9 +198,12 @@ SQLite3PreparedStatement >> checkOk: aValue [
 ]
 
 { #category : #bindings }
-SQLite3PreparedStatement >> clearBindings [ 
+SQLite3PreparedStatement >> clearBindings [
 
-	^self library clearBindings: handle on: connection handle
+	| cleared |
+	cleared := self library clearBindings: handle on: connection handle.
+	bindings removeAll.
+	^cleared
 ]
 
 { #category : #public }
@@ -302,6 +321,7 @@ SQLite3PreparedStatement >> handle [
 SQLite3PreparedStatement >> initialize [
 
 	super initialize.
+	bindings := IdentityDictionary new.
 	handle := SQLite3StatementExternalObject new.
 	handle autoRelease
 ]


### PR DESCRIPTION
Reengineer the way we bind text and blob parameters to avoid segfaults in Pharo 10.

Instead of asking SQLite to take a copy of the parameters we fully manage the lifetime of those bound parameters.

We do so by using `SQLITE_STATIC` instead of `SQLITE_TRANSIENT` as the fifth argument to `sqlite3_bind_text()` and `sqlite3_bind_blob()`. To avoid lifetime issues (i.e. the Smalltalk objects being garbage collected while the statement object on the C side is still referring to them) we keep a cache of the bound parameters and clear that whenever we clear the bindings. 