### PR TITLE
Avoid double free by marking the handle with null

### DIFF
--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -64,12 +64,12 @@ BaselineOfSQLite3 >> versionSpecificBaseline: spec [
 			package: 'SQLite3-Pharo8';
 			group: 'Core' with: 'SQLite3-Pharo8' ].
 
-	spec for: #( #'pharo9.x' #'pharo10.x' ) do: [ 
+	spec for: #( #'pharo9.x' #'pharo10.x' #'pharo11.x' ) do: [ 
 		spec
 			package: 'SQLite3-Pharo9';
 			group: 'Core' with: 'SQLite3-Pharo9' ].
 	
-	spec for: #'pharo10.x' do: [ 
+	spec for: #( #'pharo10.x' #'pharo11.x' ) do: [ 
 		spec
 			package: 'SQLite3-Pharo10';
 			group: 'Core' with: 'SQLite3-Pharo10'.

--- a/src/SQLite3-Core/SQLite3Backup.class.st
+++ b/src/SQLite3-Core/SQLite3Backup.class.st
@@ -57,6 +57,7 @@ SQLite3Backup >> finish [
 	handle 
 		ifNotNil: [
 			library apiBackupFinish: handle.
+			handle beNull.
 			handle := nil]
 ]
 

--- a/src/SQLite3-Core/SQLite3BackupExternalReference.class.st
+++ b/src/SQLite3-Core/SQLite3BackupExternalReference.class.st
@@ -6,3 +6,9 @@ Class {
 	#superclass : #FFIOpaqueObject,
 	#category : #'SQLite3-Core-UFFI-Support'
 }
+
+{ #category : #initialization }
+SQLite3BackupExternalReference >> beNull [
+	
+	^ handle beNull
+]

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -118,6 +118,7 @@ SQLite3BaseConnection >> close [
 
 	"Let FFIExternalResourceManager take care."
 	"dbHandle ifNotNil: [ library close: dbHandle ]."
+	dbHandle beNull.
 	dbHandle := nil.
 	isOpen := false.
 ]

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -118,6 +118,7 @@ SQLite3BaseConnection >> close [
 
 	"Let FFIExternalResourceManager take care."
 	"dbHandle ifNotNil: [ library close: dbHandle ]."
+	dbHandle ifNil: [ ^ self ].
 	dbHandle beNull.
 	dbHandle := nil.
 	isOpen := false.

--- a/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3DatabaseExternalObject.class.st
@@ -8,7 +8,21 @@ Class {
 }
 
 { #category : #'instance finalization' }
-SQLite3DatabaseExternalObject class >> finalizeResourceData: resourceData [
-	SQLite3Library current 
-		ffiCall: #(int sqlite3_close_v2 (void *resourceData))
+SQLite3DatabaseExternalObject class >> doFinalizeResourceData: resourceData [
+
+	SQLite3Library current ffiCall:
+		#( int sqlite3_close_v2 #( void * resourceData ) )
+]
+
+{ #category : #finalization }
+SQLite3DatabaseExternalObject class >> finalizeResourceData: aHandle [
+
+	self doFinalizeResourceData: aHandle.
+	aHandle beNull
+]
+
+{ #category : #initialization }
+SQLite3DatabaseExternalObject >> beNull [
+
+	^ handle beNull
 ]

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -625,7 +625,10 @@ SQLite3Library >> execute: anSQLText on: aDBHandle [
 
 { #category : #operating }
 SQLite3Library >> finalize: aStatementHandle on: aDBHandle [
-	^ self checkForOk: (self apiFinalize: aStatementHandle) on: aDBHandle
+	| result |
+	result := self checkForOk: (self apiFinalize: aStatementHandle) on: aDBHandle.
+	aStatementHandle beNull.
+	^ result
 ]
 
 { #category : #accessing }

--- a/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
+++ b/src/SQLite3-Core/SQLite3StatementExternalObject.class.st
@@ -9,12 +9,21 @@ Class {
 }
 
 { #category : #'instance finalization' }
-SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
-	SQLite3Library current 
-		ffiCall: #(int sqlite3_finalize (void *aHandle))
+SQLite3StatementExternalObject class >> doFinalizeResourceData: aHandle [
+
+	SQLite3Library current ffiCall:
+		#( int sqlite3_finalize #( void * aHandle ) )
 ]
 
 { #category : #finalization }
-SQLite3StatementExternalObject >> finalizeResourceData: aHandle [
-	SQLite3Library current apiFinalize: aHandle.
+SQLite3StatementExternalObject class >> finalizeResourceData: aHandle [
+
+	self doFinalizeResourceData: aHandle.
+	aHandle beNull
+]
+
+{ #category : #initialization }
+SQLite3StatementExternalObject >> beNull [
+
+	^ handle beNull
 ]


### PR DESCRIPTION
Fix #65.

With these fixes it does not crash anymore on latest pharo 11 (image+vm).
But there are a couple of DNUs and tests are red.
