### PR TITLE
Do not set the underlying SQLite3 library handle to NULL when closing the connection

### DIFF
--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -61,9 +61,17 @@ SQLite3BaseConnectionTest >> executeInDB: anSQLText [
 
 { #category : #utilities }
 SQLite3BaseConnectionTest >> getTempPath [
-^Smalltalk os isWindows
-		        ifTrue: [ (Smalltalk os environment at: 'TMP') , '\' ]
-		        ifFalse: [ '/tmp/' ]
+
+	| env |
+	env := Smalltalk os environment.
+	^ Smalltalk os isWindows
+		  ifTrue: [ "See https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a"
+			  (env
+				   at: 'TMP'
+				   ifAbsent: [ env at: 'TEMP' ifAbsent: [ env at: 'USERPROFILE' ] ])
+			  , '\' ]
+		  ifFalse: [ "See https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html"
+			(env at: 'TMPDIR' ifAbsent: ['/tmp']), '/' ]
 ]
 
 { #category : #utilities }

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -348,7 +348,7 @@ SQLite3BaseConnectionTest >> testBooleanWriteThenRead [
 SQLite3BaseConnectionTest >> testCloseFile [
 
 	| fileName newConnection path |
-	path := Smalltalk os isWindows ifTrue: [ (Smalltalk os environment at: 'TMP'), '\' ] ifFalse: [ (Smalltalk os environment at: 'TMPDIR'), '/' ].
+	path := Smalltalk os isWindows ifTrue: [ (Smalltalk os environment at: 'TMP'), '\' ] ifFalse: [ '/tmp/' ].
 	fileName := path, UUID new asString.
 	newConnection := (SQLite3BaseConnection on: fileName).
 	newConnection open; close.

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -59,11 +59,24 @@ SQLite3BaseConnectionTest >> executeInDB: anSQLText [
 	self assert: result equals: 0
 ]
 
-{ #category : #tests }
+{ #category : #utilities }
+SQLite3BaseConnectionTest >> getTempPath [
+^Smalltalk os isWindows
+		        ifTrue: [ (Smalltalk os environment at: 'TMP') , '\' ]
+		        ifFalse: [ '/tmp/' ]
+]
+
+{ #category : #utilities }
 SQLite3BaseConnectionTest >> invalidFileNameOnCurrentOperatingSystem [
 	^Smalltalk os isWindows
 		ifTrue: [ '/&*no' ]
 		ifFalse: [ '/nosuchfile' ]
+]
+
+{ #category : #utilities }
+SQLite3BaseConnectionTest >> newUniqueFileName [
+
+	^ self getTempPath , UUID new asString
 ]
 
 { #category : #tests }
@@ -347,14 +360,17 @@ SQLite3BaseConnectionTest >> testBooleanWriteThenRead [
 { #category : #'tests - connections' }
 SQLite3BaseConnectionTest >> testCloseFile [
 
-	| fileName newConnection path |
-	path := Smalltalk os isWindows ifTrue: [ (Smalltalk os environment at: 'TMP'), '\' ] ifFalse: [ '/tmp/' ].
-	fileName := path, UUID new asString.
-	newConnection := (SQLite3BaseConnection on: fileName).
-	newConnection open; close.
+	| fileName newConnection |
+	fileName := self newUniqueFileName.
+	newConnection := SQLite3BaseConnection on: fileName.
+	newConnection
+		open;
+		close.
 	newConnection := nil.
 	Smalltalk garbageCollect.
-	self shouldnt: [ File deleteFile: fileName ] raise: CannotDeleteFileException.
+	self
+		shouldnt: [ File deleteFile: fileName ]
+		raise: CannotDeleteFileException
 ]
 
 { #category : #'tests - columns' }

--- a/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLite3BaseConnectionTest.class.st
@@ -344,6 +344,19 @@ SQLite3BaseConnectionTest >> testBooleanWriteThenRead [
 		]
 ]
 
+{ #category : #'tests - connections' }
+SQLite3BaseConnectionTest >> testCloseFile [
+
+	| fileName newConnection path |
+	path := Smalltalk os isWindows ifTrue: [ (Smalltalk os environment at: 'TMP'), '\' ] ifFalse: [ (Smalltalk os environment at: 'TMPDIR'), '/' ].
+	fileName := path, UUID new asString.
+	newConnection := (SQLite3BaseConnection on: fileName).
+	newConnection open; close.
+	newConnection := nil.
+	Smalltalk garbageCollect.
+	self shouldnt: [ File deleteFile: fileName ] raise: CannotDeleteFileException.
+]
+
 { #category : #'tests - columns' }
 SQLite3BaseConnectionTest >> testColumnNames [
 

--- a/src/SQLite3-Core/SQLite3BaseConnection.class.st
+++ b/src/SQLite3-Core/SQLite3BaseConnection.class.st
@@ -115,13 +115,13 @@ SQLite3BaseConnection >> clearBindings: aStatement [
 
 { #category : #'public API - open/close' }
 SQLite3BaseConnection >> close [
+	"Do the minimal work to close the connection. 	Let FFIExternalResourceManager take care of calling sqlite_close_v2()."
 
-	"Let FFIExternalResourceManager take care."
-	"dbHandle ifNotNil: [ library close: dbHandle ]."
 	dbHandle ifNil: [ ^ self ].
-	dbHandle beNull.
+	"Set dbHandle to nil to allow its garbage collection.
+	The underlying handle should not be switched to NULL here, SQLite3DatabaseExternalObject class>>doFinalizeResourceData: will take care of that"
 	dbHandle := nil.
-	isOpen := false.
+	isOpen := false
 ]
 
 { #category : #'public API - introspection' }


### PR DESCRIPTION
Do not set the underlying SQLite3 library handle to NULL when closing the connection.

Doing so has the side effect of turning sqlite3_close_v2() into a no-op when invoked from SQLite3DatabaseExternalObject>>doFinalizeResourceData: