### PR TITLE
Add /usr/lib64 to unix64 search path

### DIFF
--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -753,7 +753,7 @@ SQLite3Library >> unix32LibraryName [
 
 { #category : #'private - accessing' }
 SQLite3Library >> unix64LibraryName [
-	(#('/usr/lib/x86_64-linux-gnu' '/lib/x86_64-linux-gnu' '/usr/lib'),
+	(#('/usr/lib/x86_64-linux-gnu' '/lib/x86_64-linux-gnu' '/usr/lib64' '/usr/lib'),
 			((OSEnvironment current at: 'LD_LIBRARY_PATH' ifAbsent: [ '' ]) substrings: ':'))
 		do: [ :path |
 			#('libsqlite3.so.0' 'libsqlite3.so') do: [ :libraryName |


### PR DESCRIPTION
In Fedora (and probably other distributions), 64-bit shared libraries are in `/usr/lib64`. This change allows `SQLite3Library` to load the 64-bit shared object on these systems.