### PR TITLE
Update BaselineOfSQLite3 - remove pinned version of glorp

### DIFF
--- a/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
+++ b/src/BaselineOfSQLite3/BaselineOfSQLite3.class.st
@@ -49,7 +49,7 @@ BaselineOfSQLite3 >> projectClass [
 BaselineOfSQLite3 >> setUpDependencies: spec [
 
 	spec
-		baseline: 'Glorp' with: [ spec repository: 'github://pharo-rdbms/glorp:v9.0.6/' ];
+		baseline: 'Glorp' with: [ spec repository: 'github://pharo-rdbms/glorp/' ];
 		project: 'Glorp-Core' copyFrom: 'Glorp' with: [ spec loads: 'Core' ];
 		project: 'Glorp-Tests' copyFrom: 'Glorp' with: [ spec loads: 'Glorp-Integration-Tests' ]
 ]


### PR DESCRIPTION
remove pinned glorp verision and now loads the latest master branch.